### PR TITLE
feat: add support and terms pages with footer (#34)

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -81,17 +81,21 @@ body {
   color: var(--color-text-primary);
   min-height: 100vh;
   display: flex;
+  flex-direction: column;   
   align-items: center;
-  justify-content: center;
   padding: 32px 16px;
-  overflow-x: hidden;
 }
 
 /* Animations */
 @keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes popIn { 0% { transform: scale(0.95); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
 
-.wrapper { width: 100%; max-width: 1200px; animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+.wrapper {
+  width: 100%;
+  max-width: 1200px;
+  animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+  flex: 1;  
+}
 
 .label {
   font-size: 12px; font-weight: 600; color: var(--color-text-tertiary);
@@ -101,7 +105,7 @@ body {
 .app {
   display: grid;
   grid-template-columns: 240px 1fr 340px;
-  height: 720px;
+  min-height: 720px;
   border: 1px solid var(--color-border-tertiary);
   border-radius: var(--border-radius-lg);
   overflow: hidden;
@@ -252,3 +256,21 @@ body {
 
 /* Utility classes */
 .hidden { display: none !important; }
+.footer {
+  width: 100%;
+  text-align: center;
+  padding: 16px;
+  margin-top: 10px;
+  color: var(--color-text-secondary);
+}
+
+.footer a {
+  margin: 0 12px;
+  text-decoration: none;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.footer a:hover {
+  color: var(--color-text-primary);
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>StudyPlan</title>
-  <link rel="stylesheet" href="/css/index.css">
+  <link rel="stylesheet" href="css/index.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -101,6 +101,10 @@
     </div>
   </div>
 </div>
+<footer class="footer">
+  <a href="support.html">Support</a>
+  <a href="terms.html">Terms</a>
+</footer>
 
   <script type="module" src="/js/app.js"></script>
 </body>

--- a/support.html
+++ b/support.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Support</title>
+</head>
+<body>
+  <h1>Support</h1>
+  <p>If you need help, contact us at support@example.com</p>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Terms & Conditions</title>
+</head>
+<body>
+  <h1>Terms & Conditions</h1>
+  <p>By using this website, you agree to our terms.</p>
+</body>
+</html>


### PR DESCRIPTION
Closes #34

## Problem
The application includes footer links for Support and Terms, but no corresponding pages exist. This makes the UI feel incomplete and less professional.

## Solution
Added dedicated pages and integrated them into the UI:

- Created `support.html` and `terms.html`
- Added a footer section with navigation links
- Ensured proper placement of the footer below the main layout

## Implementation Details
- Footer is placed outside the main layout to avoid grid/flex conflicts
- Used relative paths for CSS and links to support local development
- Updated layout to use flexible height (`min-height`) instead of fixed height

## Result
- Improves overall user experience
- Makes the application more complete and professional
- Footer links now function correctly

## Note
This is a minimal implementation. Additional content or styling enhancements can be added in future improvements.