### PR TITLE
fix:add missing .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_gemini_api_key_here


### PR DESCRIPTION
## What this fixes
The README and project structure both reference `.env.example` 
but the file doesn't exist in the repo. New contributors get 
a confusing error when following the setup instructions.

## Changes made
- Added `.env.example` with a placeholder Gemini API key

## How to test
Clone the repo fresh and follow README setup instructions — 
the copy command now works correctly.