### PR TITLE
fix: remove postinstall script that breaks Windows setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node server.js",
-    "postinstall": "npm rebuild sqlite3 --build-from-source"
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Problem
The postinstall script in package.json forces sqlite3 to 
rebuild from C++ source on every npm install:

"postinstall": "npm rebuild sqlite3 --build-from-source"

This breaks setup for any Windows developer without Visual 
Studio's C++ build tools installed, which is not listed as 
a prerequisite anywhere in the README.

## Impact
Every Windows contributor hits this error on fresh install,
regardless of Node version.

## Fix
Removed the postinstall script. npm now downloads a prebuilt 
sqlite3 binary instead of compiling from source — which works 
on all platforms without additional dependencies.

## Tested on
- Windows 11, Node 20.x — npm install succeeds cleanly

Resolves #51 