### PR TITLE
feat: add lightweight NLP module for date extraction from raw text (closes #15) NSoC'26

### DIFF
--- a/js/utils/aiMock.js
+++ b/js/utils/aiMock.js
@@ -1,46 +1,138 @@
+
+// Heuristic NLP fallback — used client-side when Gemini API is unavailable.
+
+import { extractDate } from './nlpDateExtractor.js';
+import { detectSubject } from './nlpSubjectExtractor.js';
+
+const TASK_VERBS = [
+  'submit', 'finish', 'complete', 'hand in', 'turn in', 'upload',
+  'send', 'write', 'prepare', 'present', 'review', 'read', 'study',
+  'practice', 'do', 'work on', 'draft', 'revise', 'email',
+];
+
+const ICONS = {
+  'Computer Science': '💻',
+  'Mathematics': '📐',
+  'English Lit': '📖',
+  'Physics': '⚗️',
+  default: '📚',
+};
+
+function splitIntoSegments(text) {
+  return text
+    .split(/[\n\r]+|(?<=\.)\s+(?=[A-Z])|(?:\d+[.)]\s*)/)
+    .map(s => s.trim())
+    .filter(s => s.length > 8);
+}
+
+function taskLikelihood(segment) {
+  const lower = segment.toLowerCase();
+  let score = 0;
+
+  for (const verb of TASK_VERBS) {
+    if (lower.includes(verb)) { score += 30; break; }
+  }
+
+  const dateSignals = [
+    'due', 'deadline', 'by', 'before', 'submit', 'tomorrow', 'next',
+    'today', 'week', 'month', 'monday', 'tuesday', 'wednesday',
+    'thursday', 'friday', 'saturday', 'sunday',
+    /\d+\/\d+/, /\d{1,2}(st|nd|rd|th)/,
+  ];
+  for (const sig of dateSignals) {
+    if (sig instanceof RegExp ? sig.test(lower) : lower.includes(sig)) {
+      score += 25; break;
+    }
+  }
+
+  if (segment.length > 15 && segment.length < 300) score += 15;
+  if (detectSubject(segment)) score += 20;
+
+  const fillers = ['hi ', 'hello', 'hey ', 'dear ', 'regards', 'thanks', 'sincerely'];
+  for (const f of fillers) {
+    if (lower.startsWith(f)) { score -= 40; break; }
+  }
+
+  return Math.max(0, Math.min(100, score));
+}
+
+function extractTitle(segment) {
+  let title = segment
+    .replace(/^(please|kindly|remember to|don't forget to|make sure to)\s+/i, '')
+    .replace(/\s+(by|before|due|on|at)\s+.*/i, '')
+    .trim();
+
+  if (title.length > 80) title = title.substring(0, 77) + '...';
+  return title.charAt(0).toUpperCase() + title.slice(1);
+}
+
+function getFallbackDate() {
+  const d = new Date();
+  d.setDate(d.getDate() + 7);
+  d.setHours(23, 59, 0, 0);
+  return d.toISOString();
+}
+
+function buildNotes(segment, due_at) {
+  if (!due_at) return 'No deadline found — please set manually.';
+  const quoted = segment.match(/"([^"]+)"/);
+  if (quoted) return quoted[1];
+  const afterColon = segment.match(/:\s*(.{10,60})/);
+  if (afterColon) return afterColon[1].trim();
+  return 'Extracted by heuristic NLP parser.';
+}
+
 export function extractTasksFromText(text) {
   return new Promise((resolve) => {
     setTimeout(() => {
+      const now = new Date();
+      const segments = splitIntoSegments(text);
       const results = [];
-      const lower = text.toLowerCase();
-      
-      if (lower.includes('os assignment') || lower.includes('scheduling')) {
+      const seen = new Set();
+
+      for (const segment of segments) {
+        if (taskLikelihood(segment) < 30) continue;
+
+        const due_at = extractDate(segment, now) || getFallbackDate();
+        const subjectName = detectSubject(segment);
+        const title = extractTitle(segment);
+
+        if (!title || title.length < 4) continue;
+
+        const key = title.toLowerCase().substring(0, 20);
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        const confidence = Math.min(
+          95,
+          taskLikelihood(segment) + (extractDate(segment, now) ? 10 : 0) + (subjectName ? 10 : 0)
+        );
+
         results.push({
-          subjectId: 'sub_1',
-          title: 'OS Assignment 3 — Scheduling Algorithms',
-          dueAt: '2026-04-12T23:00:00',
-          priority: 'high',
-          confidence: 88,
-          notes: 'Submit via portal, include Gantt chart',
-          icon: '📅'
+          subject_name: subjectName || 'General',
+          title,
+          due_at,
+          notes: buildNotes(segment, extractDate(segment, now)),
+          icon: ICONS[subjectName] || ICONS.default,
+          confidence_score: confidence,
+          priority: confidence > 70 ? 'high' : 'medium',
         });
       }
-      if (lower.includes('maths') || lower.includes('integration')) {
-        results.push({
-          subjectId: 'sub_2',
-          title: 'Integration problem set (Ch. 5)',
-          dueAt: '2026-04-16T17:00:00',
-          priority: 'medium',
-          confidence: 62,
-          notes: 'Date inferred — please confirm',
-          icon: '❓'
-        });
-      }
-      
-      // Fallback
+
+      // Fallback if nothing detected
       if (results.length === 0 && text.trim().length > 5) {
         results.push({
-          subjectId: 'sub_4',
-          title: 'Notes & Deadlines Extraction',
-          dueAt: '2026-04-20T12:00:00',
+          subject_name: 'General',
+          title: text.trim().substring(0, 60),
+          due_at: getFallbackDate(),
+          notes: 'Could not parse details — please edit manually.',
+          icon: '❓',
+          confidence_score: 30,
           priority: 'medium',
-          confidence: 45,
-          notes: 'Manually verify details',
-          icon: '❓'
         });
       }
-      
-      resolve(results);
-    }, 1200); // simulate network latency
+
+      resolve(results.slice(0, 10));
+    }, 800);
   });
 }

--- a/js/utils/nlpDateExtractor.js
+++ b/js/utils/nlpDateExtractor.js
@@ -1,0 +1,203 @@
+export function extractDate(text, now = new Date()) {
+  const lower = text.toLowerCase();
+
+  const relativeDay = matchRelativeDay(lower, now);
+  if (relativeDay) return withTime(relativeDay, extractTime(lower));
+
+  const inN = matchInNDaysWeeks(lower, now);
+  if (inN) return withTime(inN, extractTime(lower));
+
+  const weekday = matchNamedWeekday(lower, now);
+  if (weekday) return withTime(weekday, extractTime(lower));
+
+  const absolute = matchAbsoluteDate(lower, now);
+  if (absolute) return withTime(absolute, extractTime(lower));
+
+  const eop = matchEndOfPeriod(lower, now);
+  if (eop) return withTime(eop, extractTime(lower));
+
+  return null;
+}
+
+function addDays(date, n) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+function startOf(date) {
+  const d = new Date(date);
+  d.setHours(23, 59, 0, 0); 
+  return d;
+}
+
+function toISO(date) {
+  return date.toISOString();
+}
+
+function withTime(dateStr, timeParts) {
+  const d = new Date(dateStr);
+  if (timeParts) {
+    d.setHours(timeParts.hours, timeParts.minutes, 0, 0);
+  }
+  return toISO(d);
+}
+
+export function extractTime(text) {
+  const lower = text.toLowerCase();
+
+  if (/\bmidnight\b/.test(lower)) return { hours: 23, minutes: 59 };
+  if (/\bnoon\b/.test(lower)) return { hours: 12, minutes: 0 };
+
+  // HH:MM am/pm
+  let m = lower.match(/\b(\d{1,2}):(\d{2})\s*(am|pm)?\b/);
+  if (m) {
+    let h = parseInt(m[1]);
+    const min = parseInt(m[2]);
+    const meridiem = m[3];
+    if (meridiem === 'pm' && h < 12) h += 12;
+    if (meridiem === 'am' && h === 12) h = 0;
+    return { hours: h, minutes: min };
+  }
+
+  m = lower.match(/\b(\d{1,2})\s*(am|pm)\b/);
+  if (m) {
+    let h = parseInt(m[1]);
+    const meridiem = m[2];
+    if (meridiem === 'pm' && h < 12) h += 12;
+    if (meridiem === 'am' && h === 12) h = 0;
+    return { hours: h, minutes: 0 };
+  }
+
+  return null;
+}
+
+function matchRelativeDay(lower, now) {
+  if (/\btoday\b/.test(lower)) return toISO(startOf(now));
+  if (/\btomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 1)));
+  if (/\bday after tomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 2)));
+  if (/\byesterday\b/.test(lower)) return toISO(startOf(addDays(now, -1))); // edge case
+  return null;
+}
+
+function matchInNDaysWeeks(lower, now) {
+  let m = lower.match(/\bin\s+(\d+|a|an|one|two|three|four|five|six|seven)\s+(day|days|week|weeks|month|months)\b/);
+  if (!m) return null;
+
+  const rawN = m[1];
+  const unit = m[2];
+  const wordMap = { a: 1, an: 1, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7 };
+  const n = isNaN(rawN) ? (wordMap[rawN] || 1) : parseInt(rawN);
+
+  let d = new Date(now);
+  if (unit.startsWith('day')) d = addDays(d, n);
+  else if (unit.startsWith('week')) d = addDays(d, n * 7);
+  else if (unit.startsWith('month')) d.setMonth(d.getMonth() + n);
+
+  return toISO(startOf(d));
+}
+const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+
+function matchNamedWeekday(lower, now) {
+  const pattern = new RegExp(
+    `\\b(next|this|on|coming)?\\s*(${WEEKDAYS.join('|')})\\b`
+  );
+  const m = lower.match(pattern);
+  if (!m) return null;
+
+  const qualifier = m[1] || '';
+  const targetDay = WEEKDAYS.indexOf(m[2]);
+  const currentDay = now.getDay();
+
+  let diff = targetDay - currentDay;
+
+  if (qualifier === 'next') {
+    // Always go to NEXT week's instance
+    if (diff <= 0) diff += 7;
+    diff += (diff === 0 ? 7 : 0); // if same day, also push a week
+  } else if (qualifier === 'this') {
+    // This week — if already passed, stay same
+    if (diff < 0) diff += 7;
+  } else {
+    // No qualifier: if day already passed today, go to next week
+    if (diff <= 0) diff += 7;
+  }
+
+  return toISO(startOf(addDays(now, diff)));
+}
+const MONTHS = {
+  jan: 0, january: 0,
+  feb: 1, february: 1,
+  mar: 2, march: 2,
+  apr: 3, april: 3,
+  may: 4,
+  jun: 5, june: 5,
+  jul: 6, july: 6,
+  aug: 7, august: 7,
+  sep: 8, september: 8,
+  oct: 9, october: 9,
+  nov: 10, november: 10,
+  dec: 11, december: 11,
+};
+
+function matchAbsoluteDate(lower, now) {
+  // "april 25", "25 april", "25th april", "april 25th"
+  const monthNames = Object.keys(MONTHS).join('|');
+  const ordinal = `(\\d{1,2})(?:st|nd|rd|th)?`;
+
+  let m;
+
+  m = lower.match(new RegExp(`\\b(${monthNames})\\s+${ordinal}\\b`));
+  if (m) {
+    const month = MONTHS[m[1]];
+    const day = parseInt(m[2]);
+    return toISO(startOf(resolveYear(now, month, day)));
+  }
+
+  m = lower.match(new RegExp(`\\b${ordinal}\\s+(${monthNames})\\b`));
+  if (m) {
+    const day = parseInt(m[1]);
+    const month = MONTHS[m[2]];
+    return toISO(startOf(resolveYear(now, month, day)));
+  }
+
+  m = lower.match(/\b(\d{1,2})[\/\-\.](\d{1,2})(?:[\/\-\.](\d{2,4}))?\b/);
+  if (m) {
+    const day = parseInt(m[1]);
+    const month = parseInt(m[2]) - 1;
+    const year = m[3] ? (m[3].length === 2 ? 2000 + parseInt(m[3]) : parseInt(m[3])) : null;
+    return toISO(startOf(resolveYear(now, month, day, year)));
+  }
+
+  return null;
+}
+
+function resolveYear(now, month, day, explicitYear = null) {
+  if (explicitYear) return new Date(explicitYear, month, day);
+  const candidate = new Date(now.getFullYear(), month, day);
+  if (candidate < now) candidate.setFullYear(candidate.getFullYear() + 1);
+  return candidate;
+}
+
+function matchEndOfPeriod(lower, now) {
+  if (/\bend of (the\s+)?week\b/.test(lower) || /\bby (the\s+)?weekend\b/.test(lower)) {
+    // Next Sunday
+    const d = new Date(now);
+    d.setDate(d.getDate() + (7 - d.getDay()));
+    return toISO(startOf(d));
+  }
+  if (/\bend of (the\s+)?month\b/.test(lower)) {
+    const d = new Date(now.getFullYear(), now.getMonth() + 1, 0); // last day of month
+    return toISO(startOf(d));
+  }
+  if (/\bend of (the\s+)?year\b/.test(lower)) {
+    const d = new Date(now.getFullYear(), 11, 31);
+    return toISO(startOf(d));
+  }
+  if (/\bnext month\b/.test(lower)) {
+    const d = new Date(now);
+    d.setMonth(d.getMonth() + 1);
+    return toISO(startOf(d));
+  }
+  return null;
+}

--- a/js/utils/nlpSubjectExtractor.js
+++ b/js/utils/nlpSubjectExtractor.js
@@ -1,0 +1,57 @@
+// Mapping the raw text to a subject name using keyword heuristics.
+const SUBJECT_KEYWORDS = {
+  'Computer Science': [
+    'cs', 'computer science', 'programming', 'code', 'coding', 'algorithm',
+    'data structure', 'software', 'python', 'java', 'javascript', 'html',
+    'css', 'database', 'sql', 'network', 'operating system', 'os', 'web',
+    'cybersecurity', 'machine learning', 'ai', 'artificial intelligence',
+    'project', 'repo', 'github', 'assignment', 'lab report'
+  ],
+  'Mathematics': [
+    'maths', 'math', 'mathematics', 'calculus', 'algebra', 'geometry',
+    'statistics', 'probability', 'theorem', 'proof', 'equation',
+    'integral', 'derivative', 'matrix', 'vector', 'trigonometry',
+    'problem set', 'pset', 'worksheet'
+  ],
+  'English Lit': [
+    'english', 'literature', 'essay', 'essay', 'novel', 'poem', 'poetry',
+    'shakespeare', 'writing', 'prose', 'narrative', 'analysis', 'literary',
+    'book report', 'reading', 'chapter', 'author', 'character', 'plot',
+    'thesis', 'draft', 'revision', 'bibliography'
+  ],
+  'Physics': [
+    'physics', 'mechanics', 'thermodynamics', 'optics', 'electromagnetism',
+    'quantum', 'relativity', 'velocity', 'acceleration', 'force', 'energy',
+    'momentum', 'lab', 'experiment', 'wave', 'particle', 'newton',
+    'circuit', 'resistance', 'voltage', 'current'
+  ],
+};
+
+/**
+ * @param {string} text
+ * @returns {string|null}
+ */
+export function detectSubject(text) {
+  const lower = text.toLowerCase();
+  const scores = {};
+
+  for (const [subject, keywords] of Object.entries(SUBJECT_KEYWORDS)) {
+    scores[subject] = 0;
+    for (const kw of keywords) {
+      // Word-boundary match scores higher for short keywords
+      const re = new RegExp(`\\b${escapeRegex(kw)}\\b`, 'gi');
+      const matches = lower.match(re);
+      if (matches) {
+        // Longer keywords = stronger signal
+        scores[subject] += matches.length * (kw.length > 5 ? 2 : 1);
+      }
+    }
+  }
+
+  const best = Object.entries(scores).sort((a, b) => b[1] - a[1])[0];
+  return best && best[1] > 0 ? best[0] : null;
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/server.js
+++ b/server.js
@@ -9,7 +9,6 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-// Static
 app.use('/css', express.static(path.join(__dirname, 'css')));
 app.use('/js', express.static(path.join(__dirname, 'js')));
 app.use(express.static(__dirname));
@@ -20,7 +19,208 @@ const ai = process.env.GEMINI_API_KEY
   ? new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY })
   : null;
 
-// ================= SUBJECTS =================
+function nlpAddDays(date, n) {
+  const d = new Date(date); d.setDate(d.getDate() + n); return d;
+}
+function nlpStartOf(date) {
+  const d = new Date(date); d.setHours(23, 59, 0, 0); return d;
+}
+function nlpWithTime(dateStr, t) {
+  const d = new Date(dateStr);
+  if (t) d.setHours(t.hours, t.minutes, 0, 0);
+  return d.toISOString();
+}
+
+function nlpExtractTime(lower) {
+  if (/\bmidnight\b/.test(lower)) return { hours: 23, minutes: 59 };
+  if (/\bnoon\b/.test(lower)) return { hours: 12, minutes: 0 };
+  let m = lower.match(/\b(\d{1,2}):(\d{2})\s*(am|pm)?\b/);
+  if (m) {
+    let h = parseInt(m[1]); const min = parseInt(m[2]); const mer = m[3];
+    if (mer === 'pm' && h < 12) h += 12;
+    if (mer === 'am' && h === 12) h = 0;
+    return { hours: h, minutes: min };
+  }
+  m = lower.match(/\b(\d{1,2})\s*(am|pm)\b/);
+  if (m) {
+    let h = parseInt(m[1]); const mer = m[2];
+    if (mer === 'pm' && h < 12) h += 12;
+    if (mer === 'am' && h === 12) h = 0;
+    return { hours: h, minutes: 0 };
+  }
+  return null;
+}
+
+const NLP_WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+const NLP_MONTHS = {
+  jan:0,january:0,feb:1,february:1,mar:2,march:2,apr:3,april:3,may:4,
+  jun:5,june:5,jul:6,july:6,aug:7,august:7,sep:8,september:8,
+  oct:9,october:9,nov:10,november:10,dec:11,december:11
+};
+
+function nlpResolveYear(now, month, day, explicitYear = null) {
+  if (explicitYear) return new Date(explicitYear, month, day);
+  const c = new Date(now.getFullYear(), month, day);
+  if (c < now) c.setFullYear(c.getFullYear() + 1);
+  return c;
+}
+
+function nlpExtractDate(text, now = new Date()) {
+  const lower = text.toLowerCase();
+  const time = nlpExtractTime(lower);
+
+  if (/\btoday\b/.test(lower)) return nlpWithTime(nlpStartOf(now).toISOString(), time);
+  if (/\bday after tomorrow\b/.test(lower)) return nlpWithTime(nlpStartOf(nlpAddDays(now, 2)).toISOString(), time);
+  if (/\btomorrow\b/.test(lower)) return nlpWithTime(nlpStartOf(nlpAddDays(now, 1)).toISOString(), time);
+
+  let m = lower.match(/\bin\s+(\d+|a|an|one|two|three|four|five|six|seven)\s+(day|days|week|weeks|month|months)\b/);
+  if (m) {
+    const wm = { a:1,an:1,one:1,two:2,three:3,four:4,five:5,six:6,seven:7 };
+    const n = isNaN(m[1]) ? (wm[m[1]] || 1) : parseInt(m[1]);
+    let d = new Date(now);
+    if (m[2].startsWith('day')) d = nlpAddDays(d, n);
+    else if (m[2].startsWith('week')) d = nlpAddDays(d, n * 7);
+    else d.setMonth(d.getMonth() + n);
+    return nlpWithTime(nlpStartOf(d).toISOString(), time);
+  }
+
+  const wdPattern = new RegExp(`\\b(next|this|on|coming)?\\s*(${NLP_WEEKDAYS.join('|')})\\b`);
+  m = lower.match(wdPattern);
+  if (m) {
+    const target = NLP_WEEKDAYS.indexOf(m[2]);
+    const cur = now.getDay();
+    let diff = target - cur;
+    if (diff <= 0) diff += 7;
+    return nlpWithTime(nlpStartOf(nlpAddDays(now, diff)).toISOString(), time);
+  }
+
+  const monthNames = Object.keys(NLP_MONTHS).join('|');
+  const ord = `(\\d{1,2})(?:st|nd|rd|th)?`;
+  m = lower.match(new RegExp(`\\b(${monthNames})\\s+${ord}\\b`));
+  if (m) return nlpWithTime(nlpStartOf(nlpResolveYear(now, NLP_MONTHS[m[1]], parseInt(m[2]))).toISOString(), time);
+  m = lower.match(new RegExp(`\\b${ord}\\s+(${monthNames})\\b`));
+  if (m) return nlpWithTime(nlpStartOf(nlpResolveYear(now, NLP_MONTHS[m[2]], parseInt(m[1]))).toISOString(), time);
+
+  m = lower.match(/\b(\d{1,2})[\/\-\.](\d{1,2})(?:[\/\-\.](\d{2,4}))?\b/);
+  if (m) {
+    const day = parseInt(m[1]), month = parseInt(m[2]) - 1;
+    const yr = m[3] ? (m[3].length === 2 ? 2000 + parseInt(m[3]) : parseInt(m[3])) : null;
+    return nlpWithTime(nlpStartOf(nlpResolveYear(now, month, day, yr)).toISOString(), time);
+  }
+
+  if (/\bend of (the\s+)?week\b/.test(lower) || /\bby (the\s+)?weekend\b/.test(lower)) {
+    const d = new Date(now); d.setDate(d.getDate() + (7 - d.getDay()));
+    return nlpStartOf(d).toISOString();
+  }
+  if (/\bend of (the\s+)?month\b/.test(lower)) {
+    return nlpStartOf(new Date(now.getFullYear(), now.getMonth() + 1, 0)).toISOString();
+  }
+  if (/\bnext month\b/.test(lower)) {
+    const d = new Date(now); d.setMonth(d.getMonth() + 1);
+    return nlpStartOf(d).toISOString();
+  }
+
+  return null;
+}
+
+const NLP_SUBJECT_KEYWORDS = {
+  'Computer Science': ['cs','computer science','programming','code','coding','algorithm','data structure','software','python','java','javascript','html','database','sql','network','operating system','os','web','scheduling','lab report','assignment'],
+  'Mathematics': ['maths','math','mathematics','calculus','algebra','statistics','probability','theorem','equation','integral','derivative','matrix','vector','problem set','pset','worksheet','integration'],
+  'English Lit': ['english','literature','essay','novel','poem','poetry','shakespeare','writing','prose','narrative','analysis','literary','book report','reading','thesis','draft','revision'],
+  'Physics': ['physics','mechanics','thermodynamics','optics','velocity','acceleration','force','energy','momentum','lab','experiment','wave','circuit','resistance','voltage'],
+};
+
+function nlpDetectSubject(text) {
+  const lower = text.toLowerCase();
+  const scores = {};
+  for (const [sub, kws] of Object.entries(NLP_SUBJECT_KEYWORDS)) {
+    scores[sub] = 0;
+    for (const kw of kws) {
+      const re = new RegExp(`\\b${kw.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')}\\b`, 'gi');
+      const hits = lower.match(re);
+      if (hits) scores[sub] += hits.length * (kw.length > 5 ? 2 : 1);
+    }
+  }
+  const best = Object.entries(scores).sort((a, b) => b[1] - a[1])[0];
+  return best && best[1] > 0 ? best[0] : null;
+}
+
+const NLP_TASK_VERBS = ['submit','finish','complete','hand in','turn in','upload','send','write','prepare','present','review','read','study','draft','revise'];
+
+function nlpSplitSegments(text) {
+  return text.split(/[\n\r]+|(?<=\.)\s+(?=[A-Z])|\d+[.)]\s*/)
+    .map(s => s.trim()).filter(s => s.length > 8);
+}
+
+function nlpTaskScore(seg) {
+  const lower = seg.toLowerCase();
+  let s = 0;
+  for (const v of NLP_TASK_VERBS) if (lower.includes(v)) { s += 30; break; }
+  const sigs = ['due','deadline','by','before','submit','tomorrow','next','today','week','month',
+    'monday','tuesday','wednesday','thursday','friday','saturday','sunday',
+    /\d+\/\d+/, /\d{1,2}(st|nd|rd|th)/];
+  for (const sig of sigs) if (sig instanceof RegExp ? sig.test(lower) : lower.includes(sig)) { s += 25; break; }
+  if (seg.length > 15 && seg.length < 300) s += 15;
+  if (nlpDetectSubject(seg)) s += 20;
+  const fillers = ['hi ','hello','hey ','dear ','regards','thanks','sincerely'];
+  for (const f of fillers) if (lower.startsWith(f)) { s -= 40; break; }
+  return Math.max(0, Math.min(100, s));
+}
+
+function nlpCleanTitle(seg) {
+  return seg
+    .replace(/^(please|kindly|remember to|don't forget to|make sure to)\s+/i, '')
+    .replace(/\s+(by|before|due|on|at)\s+.*/i, '')
+    .trim().substring(0, 80);
+}
+
+function nlpFallbackDate() {
+  const d = new Date(); d.setDate(d.getDate() + 7); d.setHours(23, 59, 0, 0);
+  return d.toISOString();
+}
+
+function nlpExtractTasksFromText(text) {
+  const now = new Date();
+  const segs = nlpSplitSegments(text);
+  const results = [];
+  const seen = new Set();
+
+  for (const seg of segs) {
+    if (nlpTaskScore(seg) < 30) continue;
+    const due_at = nlpExtractDate(seg, now) || nlpFallbackDate();
+    const subjectName = nlpDetectSubject(seg);
+    const rawTitle = nlpCleanTitle(seg);
+    if (!rawTitle || rawTitle.length < 4) continue;
+    const key = rawTitle.toLowerCase().substring(0, 20);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const confidence = Math.min(95, nlpTaskScore(seg) + (nlpExtractDate(seg, now) ? 10 : 0) + (subjectName ? 10 : 0));
+    results.push({
+      title: rawTitle.charAt(0).toUpperCase() + rawTitle.slice(1),
+      subject_name: subjectName || 'General',
+      due_at,
+      notes: 'Extracted by heuristic NLP parser.',
+      icon: { 'Computer Science':'💻','Mathematics':'📐','English Lit':'📖','Physics':'⚗️' }[subjectName] || '📚',
+      confidence_score: confidence,
+      priority: confidence > 70 ? 'high' : 'medium',
+    });
+  }
+
+  if (results.length === 0 && text.trim().length > 5) {
+    results.push({
+      title: text.trim().substring(0, 60),
+      subject_name: 'General',
+      due_at: nlpFallbackDate(),
+      notes: 'Could not parse details — please edit manually.',
+      icon: '❓',
+      confidence_score: 30,
+      priority: 'medium',
+    });
+  }
+
+  return results.slice(0, 10);
+}
+
 app.get('/api/subjects', (req, res) => {
   db.all('SELECT * FROM subjects', (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
@@ -28,7 +228,6 @@ app.get('/api/subjects', (req, res) => {
   });
 });
 
-// ================= TASKS =================
 app.get('/api/tasks', (req, res) => {
   db.all('SELECT * FROM tasks ORDER BY due_at ASC', (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
@@ -36,16 +235,12 @@ app.get('/api/tasks', (req, res) => {
   });
 });
 
-// ================= ADD TASKS (FINAL FIX) =================
 app.post('/api/tasks', (req, res) => {
   try {
     const tasks = Array.isArray(req.body) ? req.body : [req.body];
 
     if (!tasks || tasks.length === 0) {
-      return res.status(400).json({
-        success: false,
-        message: "No tasks provided"
-      });
+      return res.status(400).json({ success: false, message: "No tasks provided" });
     }
 
     let inserted = 0;
@@ -59,93 +254,43 @@ app.post('/api/tasks', (req, res) => {
     let pending = tasks.length;
 
     tasks.forEach(t => {
-
-      // ================= VALIDATION =================
       if (!t.title || !t.due_at || !t.subject_id) {
         errors.push({ task: t, error: "Missing title, subject or due date" });
         pending--;
-
         if (pending === 0) {
-          stmt.finalize(() => {
-            return res.status(400).json({
-              success: false,
-              inserted,
-              duplicates,
-              errors,
-              message: "All tasks invalid"
-            });
-          });
+          stmt.finalize(() => res.status(400).json({ success: false, inserted, duplicates, errors, message: "All tasks invalid" }));
         }
         return;
       }
 
-      // ================= DUPLICATE CHECK =================
       db.get(
-        `SELECT * FROM tasks 
-         WHERE LOWER(title) = LOWER(?) 
-         AND subject_id = ?
-         AND DATE(due_at) = DATE(?)`,
+        `SELECT * FROM tasks WHERE LOWER(title) = LOWER(?) AND subject_id = ? AND DATE(due_at) = DATE(?)`,
         [t.title, t.subject_id, t.due_at],
         (err, existing) => {
-
           if (err) {
             errors.push({ task: t, error: err.message });
-          } 
-          else if (existing) {
-            duplicates.push({
-              title: t.title,
-              due_at: t.due_at,
-              subject_id: t.subject_id
-            });
-          } 
-          else {
+          } else if (existing) {
+            duplicates.push({ title: t.title, due_at: t.due_at, subject_id: t.subject_id });
+          } else {
             const id = 'task_' + Date.now() + Math.random().toString(36).substr(2, 5);
-
-            stmt.run(
-              id,
-              t.subject_id,
-              t.title,
-              t.due_at,
-              t.status || 'Not Started',
-              t.priority || 'medium',
-              t.confidence_score || 100,
-              t.notes || '',
+            stmt.run(id, t.subject_id, t.title, t.due_at, t.status || 'Not Started', t.priority || 'medium', t.confidence_score || 100, t.notes || '',
               function(insertErr) {
-                if (insertErr) {
-                  errors.push({ task: t, error: insertErr.message });
-                } else {
-                  inserted++;
-                }
+                if (insertErr) errors.push({ task: t, error: insertErr.message });
+                else inserted++;
               }
             );
           }
 
           pending--;
-
-          // ================= FINAL RESPONSE =================
           if (pending === 0) {
             stmt.finalize((finalErr) => {
-              if (finalErr) {
-                return res.status(500).json({
-                  success: false,
-                  message: "Database error",
-                  error: finalErr.message
-                });
-              }
-
+              if (finalErr) return res.status(500).json({ success: false, message: "Database error", error: finalErr.message });
               return res.json({
-                success: true,
-                inserted,
-                duplicates,
-                errors,
-                message:
-                  errors.length > 0 && duplicates.length > 0
-                    ? "Some tasks failed and some duplicates were skipped"
-                    : errors.length > 0
-                    ? "Some tasks failed to add"
-                    : duplicates.length > 0
-                    ? "Duplicate tasks were skipped"
-                    : "All tasks added successfully"
+                success: true, inserted, duplicates, errors,
+                message: errors.length > 0 && duplicates.length > 0 ? "Some tasks failed and some duplicates were skipped"
+                  : errors.length > 0 ? "Some tasks failed to add"
+                  : duplicates.length > 0 ? "Duplicate tasks were skipped"
+                  : "All tasks added successfully"
               });
             });
           }
@@ -154,99 +299,60 @@ app.post('/api/tasks', (req, res) => {
     });
 
   } catch (e) {
-    return res.status(500).json({
-      success: false,
-      message: "Unexpected server error",
-      error: e.message
-    });
+    return res.status(500).json({ success: false, message: "Unexpected server error", error: e.message });
   }
 });
 
-// ================= UPDATE =================
 app.put('/api/tasks/:id', (req, res) => {
   const { status } = req.body;
-
-  if (!status) {
-    return res.status(400).json({ error: 'Status is required' });
-  }
-
-  db.run(
-    'UPDATE tasks SET status = ? WHERE id = ?',
-    [status, req.params.id],
-    function(err) {
-      if (err) return res.status(500).json({ error: err.message });
-      res.json({ success: true, changes: this.changes });
-    }
-  );
+  if (!status) return res.status(400).json({ error: 'Status is required' });
+  db.run('UPDATE tasks SET status = ? WHERE id = ?', [status, req.params.id], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, changes: this.changes });
+  });
 });
 
-// ================= DELETE =================
 app.delete('/api/tasks/:id', (req, res) => {
-  db.run(
-    'DELETE FROM tasks WHERE id = ?',
-    [req.params.id],
-    function(err) {
-      if (err) return res.status(500).json({ error: err.message });
-      res.json({ success: true, changes: this.changes });
-    }
-  );
+  db.run('DELETE FROM tasks WHERE id = ?', [req.params.id], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true, changes: this.changes });
+  });
 });
 
-// ================= AI EXTRACTION =================
 app.post('/api/extract', async (req, res) => {
   const { text } = req.body;
-
-  if (!text) {
-    return res.status(400).json({ error: 'Text is required' });
-  }
+  if (!text) return res.status(400).json({ error: 'Text is required' });
 
   if (ai) {
     try {
       const prompt = `
-You are an AI study planner. Extract deadlines and tasks.
-Return ONLY JSON array.
+You are an AI study planner assistant. Extract ALL tasks and deadlines from the text below.
+Return ONLY a raw JSON array (no markdown, no backticks, no explanation).
+Each object must have: title (string), subject_name (string), due_at (ISO 8601 datetime), notes (string), confidence_score (number 0-100), priority ("low"|"medium"|"high"), icon (emoji).
+
 Text: "${text}"
 `;
-
       const response = await ai.models.generateContent({
         model: 'gemini-2.5-flash',
         contents: prompt
       });
 
-      let rawText = (typeof response.text === 'function'
-        ? response.text()
-        : response.text).trim();
-
-      if (rawText.startsWith('```')) {
-        rawText = rawText.replace(/```json|```/g, '').trim();
-      }
+      let rawText = (typeof response.text === 'function' ? response.text() : response.text).trim();
+      if (rawText.startsWith('```')) rawText = rawText.replace(/```json|```/g, '').trim();
 
       const data = JSON.parse(rawText);
-      res.json(data);
+      return res.json(data);
 
     } catch (e) {
-      console.error(e);
-      res.status(500).json({
-        error: 'AI Extraction failed',
-        details: e.message
-      });
+      console.error('Gemini failed, falling back to NLP heuristic:', e.message);
     }
-
-  } else {
-    setTimeout(() => {
-      res.json([{
-        subject_name: "General",
-        title: text,
-        due_at: new Date(Date.now() + 86400000).toISOString(),
-        priority: "medium",
-        confidence_score: 50,
-        notes: "Mock extraction"
-      }]);
-    }, 1000);
   }
+
+  // NLP heuristic fallback 
+  const tasks = nlpExtractTasksFromText(text);
+  return res.json(tasks);
 });
 
-// ================= SERVER =================
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log('Server running on port ' + PORT);


### PR DESCRIPTION
-NSoC'26
## Summary
Fixes #15 by replacing the hardcoded keyword mock with a genuine NLP 
heuristic pipeline for date, time, and subject extraction.

## New files
- `js/utils/nlpDateExtractor.js` :client-side NLP date/time parser (ES module)
- `js/utils/nlpSubjectExtractor.js` :keyword scoring for subject detection (ES module)

## Changes
- `js/utils/aiMock.js` :rewritten to use the new NLP modules instead of 
  hardcoded keyword checks
- `server.js`:  NLP logic inlined as fallback for when Gemini API key is 
  absent or the Gemini call fails

## What the NLP module handles
- Relative dates: "tomorrow", "in 3 days", "in two weeks"
- Named weekdays with qualifiers: "next Friday", "this Thursday", "on Monday"
- Absolute dates: "April 25th", "25 Apr", "25/04/2025"
- Time parsing: "by 11:59pm", "at 5pm", "midnight", "noon"
- End-of-period shorthands: "end of week", "end of month"
- Subject detection via weighted keyword scoring across all 4 subjects

## Before vs after
Before: fallback returned a single hardcoded task with 50% confidence 
regardless of input text.

After: fallback correctly parses multi-task inputs, extracts real 
deadlines, detects subjects, and assigns meaningful confidence scores.

## Testing
Tested locally without API key using curl and the browser UI with 
multi-line WhatsApp-style messages, emails, and assignment briefs.