### PR TITLE
Implement functional settings modal with persistent preferences

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -75,6 +75,65 @@
   }
 }
 
+:root[data-theme="dark"] {
+  --color-background-primary: #181816;
+  --color-background-secondary: #20201e;
+  --color-background-tertiary: #272725;
+  --color-text-primary: #efede5;
+  --color-text-secondary: #a3a198;
+  --color-text-tertiary: #73726c;
+  --color-border-tertiary: rgba(255,255,255,0.06);
+  --color-border-secondary: rgba(255,255,255,0.12);
+  --color-border-primary: rgba(255,255,255,0.22);
+  --color-text-danger: #fc9c9c;
+  --color-background-danger: rgba(252, 156, 156, 0.15);
+  --color-border-danger: rgba(252,156,156,0.3);
+  
+  --color-text-info: #9ecdfc;
+  --color-background-info: rgba(158, 205, 252, 0.15);
+  --color-border-info: rgba(158,205,252,0.3);
+  
+  --color-text-success: #a0d45a;
+  --color-background-success: rgba(160, 212, 90, 0.15);
+  --color-border-success: rgba(160,212,90,0.3);
+
+  --color-text-warning: #fab35e;
+  --color-background-warning: rgba(250, 179, 94, 0.15);
+
+  --color-text-purple: #b9b5f5;
+  --color-background-purple: rgba(185, 181, 245, 0.15);
+}
+
+:root[data-theme="light"] {
+  --color-background-primary: #ffffff;
+  --color-background-secondary: #f7f7f5;
+  --color-background-tertiary: #efefec;
+  --color-text-primary: #1a1a18;
+  --color-text-secondary: #6b6b66;
+  --color-text-tertiary: #9c9a92;
+  --color-border-tertiary: rgba(0,0,0,0.08); 
+  --color-border-secondary: rgba(0,0,0,0.15); 
+  --color-border-primary: rgba(0,0,0,0.30);
+  
+  --color-text-danger: #a32d2d;
+  --color-background-danger: #fcebeb;
+  --color-border-danger: rgba(163, 45, 45, 0.35);
+  
+  --color-text-info: #185fa5;
+  --color-background-info: #e6f1fb;
+  --color-border-info: rgba(24, 95, 165, 0.35);
+  
+  --color-text-success: #166534;
+  --color-background-success: #eaf3de;
+  --color-border-success: rgba(22, 101, 52, 0.35);
+
+  --color-text-warning: #854f0b;
+  --color-background-warning: #faeeda;
+  
+  --color-text-purple: #3c3489;
+  --color-background-purple: #eeedfe;
+}
+
 body {
   font-family: var(--font-sans);
   background: var(--color-background-tertiary);
@@ -424,3 +483,64 @@ body {
 .footer-links a:hover {
   color: var(--color-text-primary);
 }
+
+/* Settings Toggle Switch */
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+.toggle-switch input { 
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-color: var(--color-border-primary);
+  transition: .3s;
+  border-radius: 24px;
+}
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: var(--color-background-primary);
+  transition: .3s;
+  border-radius: 50%;
+}
+.toggle-switch input:checked + .toggle-slider {
+  background-color: var(--color-text-success);
+}
+.toggle-switch input:checked + .toggle-slider:before {
+  transform: translateX(20px);
+}
+
+/* Compact View utility classes */
+body.compact-view {
+  padding: 16px 8px;
+}
+body.compact-view .app {
+  height: 600px;
+}
+body.compact-view .task-item {
+  padding: 8px 10px;
+  margin-bottom: 4px;
+}
+body.compact-view .nav-item {
+  padding: 8px 10px;
+  font-size: 13px;
+}
+body.compact-view .topbar {
+  padding: 12px 16px;
+}
+body.compact-view .cal-section,
+body.compact-view .tasks-section {
+  padding: 12px 16px;
+}

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <a href="#">Dashboard</a>
     <a href="#">Tasks</a>
     <a href="#">Calendar</a>
-    <a href="#">Settings</a>
+    <a href="#" id="nav-settings">Settings</a>
   </nav>
 
   <div class="header-right">
@@ -164,6 +164,56 @@
   </div>
 </footer>
 
+<!-- Settings Modal -->
+<div id="settings-modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:9999; align-items:center; justify-content:center; backdrop-filter:blur(4px);">
+  <div style="background:var(--color-background-primary); border:1px solid var(--color-border-tertiary); border-radius:16px; padding:32px; width:400px; box-shadow:var(--shadow-lg); color:var(--color-text-primary);">
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:24px;">
+      <h2 style="margin:0; font-size:20px; font-weight:700;">Settings</h2>
+      <button id="settings-close" style="background:none; border:none; font-size:24px; cursor:pointer; color:var(--color-text-secondary);">&times;</button>
+    </div>
+    
+    <div style="margin-bottom: 24px;">
+      <h3 style="font-size:12px; font-weight:700; text-transform:uppercase; color:var(--color-text-tertiary); margin-bottom:16px; letter-spacing:0.05em;">Appearance</h3>
+      <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom: 16px;">
+        <span style="font-size:14px; font-weight:500;">Dark Mode</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="dark-mode-toggle">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+      <div style="display:flex; align-items:center; justify-content:space-between;">
+        <span style="font-size:14px; font-weight:500;">Compact View</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="compact-view-toggle">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+    </div>
+
+    <div style="margin-bottom: 24px;">
+      <h3 style="font-size:12px; font-weight:700; text-transform:uppercase; color:var(--color-text-tertiary); margin-bottom:16px; letter-spacing:0.05em;">Notifications</h3>
+      <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom: 16px;">
+        <span style="font-size:14px; font-weight:500;">Email Reminders</span>
+        <label class="toggle-switch">
+          <input type="checkbox" checked>
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+      <div style="display:flex; align-items:center; justify-content:space-between;">
+        <span style="font-size:14px; font-weight:500;">Browser Notifications</span>
+        <label class="toggle-switch">
+          <input type="checkbox">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+    </div>
+
+    <button id="settings-save" style="width:100%; padding:12px; background:var(--color-text-primary); color:var(--color-background-primary); border:none; border-radius:8px; font-size:14px; font-weight:600; cursor:pointer; margin-top:8px;">
+      Save Changes
+    </button>
+  </div>
+</div>
+
   <script type="module" src="/js/app.js"></script>
   <script>
   let isLogin = true;
@@ -219,6 +269,83 @@
   if (localStorage.getItem('studyplan_user')) {
     document.getElementById('auth-modal').style.display = 'none';
   }
+  // Settings Modal Logic
+  const settingsModal = document.getElementById('settings-modal');
+  const navSettings = document.getElementById('nav-settings');
+  const settingsClose = document.getElementById('settings-close');
+  const settingsSave = document.getElementById('settings-save');
+
+  navSettings.addEventListener('click', (e) => {
+    e.preventDefault();
+    settingsModal.style.display = 'flex';
+  });
+
+  settingsClose.addEventListener('click', () => {
+    settingsModal.style.display = 'none';
+  });
+
+  settingsSave.addEventListener('click', () => {
+    settingsModal.style.display = 'none';
+  });
+
+  window.addEventListener('click', (e) => {
+    if (e.target === settingsModal) {
+      settingsModal.style.display = 'none';
+    }
+  });
+
+  // Settings Toggles State Management
+  const darkModeToggle = document.getElementById('dark-mode-toggle');
+  const compactViewToggle = document.getElementById('compact-view-toggle');
+
+  // Load preferences
+  const loadPreferences = () => {
+    const isDarkMode = localStorage.getItem('studyplan_dark_mode') === 'true';
+    const isCompactView = localStorage.getItem('studyplan_compact_view') === 'true';
+
+    darkModeToggle.checked = isDarkMode;
+    compactViewToggle.checked = isCompactView;
+
+    if (isDarkMode) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+
+    if (isCompactView) {
+      document.body.classList.add('compact-view');
+    } else {
+      document.body.classList.remove('compact-view');
+    }
+  };
+
+  // Run on load
+  loadPreferences();
+
+  // Save changes when user clicks "Save Changes"
+  settingsSave.addEventListener('click', () => {
+    localStorage.setItem('studyplan_dark_mode', darkModeToggle.checked);
+    localStorage.setItem('studyplan_compact_view', compactViewToggle.checked);
+    loadPreferences();
+    settingsModal.style.display = 'none';
+  });
+
+  // Also apply immediately on toggle for better UX
+  darkModeToggle.addEventListener('change', (e) => {
+    if (e.target.checked) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  });
+
+  compactViewToggle.addEventListener('change', (e) => {
+    if (e.target.checked) {
+      document.body.classList.add('compact-view');
+    } else {
+      document.body.classList.remove('compact-view');
+    }
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
**Description:** 
This PR introduces a new fully functional Settings modal section to the frontend, aligning with the project's minimalist design aesthetic. Users can now customize their experience with persistent preferences that apply immediately upon toggling.

---

**Key Changes:**
- **Settings Modal UI**: Built a clean, floating modal dialog for the settings menu that matches the existing UI design.
- **Toggle Switches**: Created custom CSS-only toggle switches (`.toggle-switch`, `.toggle-slider`) for an improved modern user experience compared to default checkboxes.
- **Dark Mode Support**: Refactored CSS variables to support manual `[data-theme="dark"]` overriding, allowing the user to explicitly toggle dark mode independent of their system preference.
- **Compact View**: Added a `.compact-view` utility class that condenses padding across the sidebar, calendar, and task lists for a more data-dense layout.
- **Local Storage Persistence**: Hooked up JavaScript to instantly apply the chosen themes/views and save user preferences to `localStorage` so they persist across page reloads.

----

**Testing Notes:**
- Clicking "Settings" in the top navigation successfully opens the modal.
- Toggling Dark Mode immediately swaps the CSS variable scheme.
- Toggling Compact View immediately updates the global layouts.
- Refreshing the page correctly reads from `localStorage` and maintains the chosen settings.

---

**ScreenShort**

<img width="541" height="512" alt="image" src="https://github.com/user-attachments/assets/69cd4f58-6dd4-4341-837a-1c2b3bfd9e9b" />

---

**Issues** #62 


