### PR TITLE
Fix: wire Add subject modal, POST /api/subjects, dynamic sidebar

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -127,6 +127,8 @@ body {
 .sidebar-divider { height: 1px; background: var(--color-border-tertiary); margin: 12px 0; }
 .add-subject { font-size: 13px; font-weight: 500; color: var(--color-text-tertiary); padding: 8px 12px; cursor: pointer; transition: color 0.2s; display: flex; align-items: center; gap: 8px; }
 .add-subject:hover { color: var(--color-text-primary); }
+button.add-subject { border: none; background: transparent; font: inherit; margin: 0; width: 100%; text-align: left; box-sizing: border-box; }
+.subject-sidebar-row { cursor: default; }
 
 /* Main */
 .main { display: flex; flex-direction: column; overflow: hidden; position: relative; }
@@ -501,10 +503,11 @@ body {
   padding: 10px;
 }
 
-/* Task Addition Model */
+/* Task and subject modals */
 
 
-#new-task-modal{
+#new-task-modal,
+#new-subject-modal {
 
   position: fixed;
   inset: 0;
@@ -516,7 +519,8 @@ body {
 }
 
 
-#new-task-modal .modal-card {
+#new-task-modal .modal-card,
+#new-subject-modal .modal-card {
   width: 100%;
   max-width: 360px;
   background-color: #0f172a;                     
@@ -529,7 +533,8 @@ body {
 }
 
 
-#new-task-modal .modal-card h3 {
+#new-task-modal .modal-card h3,
+#new-subject-modal .modal-card h3 {
   margin: 0 0 12px;
   font-size: 18px;
   font-weight: 600;
@@ -538,7 +543,8 @@ body {
 }
 
 
-#new-task-modal label {
+#new-task-modal label,
+#new-subject-modal label {
   display: block;
   font-size: 11px;
   font-weight: 600;
@@ -550,7 +556,9 @@ body {
 
 
 #new-task-modal input,
-#new-task-modal select {
+#new-task-modal select,
+#new-subject-modal input,
+#new-subject-modal select {
   width: 100%;
   box-sizing: border-box;
   font-size: 13px;
@@ -565,13 +573,16 @@ body {
 }
 
 
-#new-task-modal input::placeholder {
+#new-task-modal input::placeholder,
+#new-subject-modal input::placeholder {
   color: #6b7280;
 }
 
 
 #new-task-modal input:focus,
-#new-task-modal select:focus {
+#new-task-modal select:focus,
+#new-subject-modal input:focus,
+#new-subject-modal select:focus {
   outline: none;
   border-color: #4f46e5;
   box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35);
@@ -579,7 +590,8 @@ body {
 }
 
 
-#new-task-modal .modal-card > div:last-child {
+#new-task-modal .modal-card > div:last-child,
+#new-subject-modal .modal-card > div:last-child {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -587,24 +599,28 @@ body {
 }
 
 
-#new-task-modal .btn {
+#new-task-modal .btn,
+#new-subject-modal .btn {
   font-size: 12px;
   padding: 6px 10px;
   border-radius: 999px;
 }
 
-#new-task-modal .btn:not(.btn-primary) {
+#new-task-modal .btn:not(.btn-primary),
+#new-subject-modal .btn:not(.btn-primary) {
   background: rgba(15, 23, 42, 0.9);
   color: #e5e7eb;
   border: 1px solid #4b5563;
 }
 
-#new-task-modal .btn:not(.btn-primary):hover {
+#new-task-modal .btn:not(.btn-primary):hover,
+#new-subject-modal .btn:not(.btn-primary):hover {
   background: #020617;
 }
 
 
-#new-task-modal.showing .modal-card {
+#new-task-modal.showing .modal-card,
+#new-subject-modal.showing .modal-card {
   animation: new-task-modal-in 0.16s ease-out;
 }
 
@@ -619,9 +635,34 @@ body {
   }
 }
 
+#new-subject-modal .subject-color-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+#new-subject-modal .subject-color-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+#new-subject-modal .subject-color-swatch.selected {
+  border-color: #818cf8;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
 
 @media (max-width: 480px) {
-  #new-task-modal .modal-card {
+  #new-task-modal .modal-card,
+  #new-subject-modal .modal-card {
     max-width: 90vw;
     padding: 16px 14px 12px;
   }

--- a/index.html
+++ b/index.html
@@ -84,13 +84,10 @@
       </div>
       <div class="sidebar-divider"></div>
       <div class="sidebar-header">Subjects</div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-info)"></span>Computer Science<span class="badge">3</span></div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-success)"></span>Mathematics<span class="badge">2</span></div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-purple)"></span>English Lit<span class="badge">1</span></div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-warning)"></span>Physics<span class="badge">1</span></div>
-      <div class="add-subject">
+      <div id="subjects-list"></div>
+      <button type="button" class="add-subject" id="add-subject-btn">
         <svg width="14" height="14" fill="none"><path d="M7 1v12M1 7h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg> Add subject
-      </div>
+      </button>
     </div>
 
     <!-- Main -->
@@ -224,7 +221,7 @@
 </script>
 
 
-//ADD TASK MODEL
+<!-- Task modal -->
 <div id="new-task-modal" class="modal-backdrop" style="display:none; position:fixed; inset:0;  z-index:9998; align-items:center; justify-content:center;">
   <div class="modal-card" style=" border-radius:12px; padding:20px; width:320px; box-shadow:0 12px 40px rgba(0,0,0,0.25);">
     <h3 style="margin:0 0 12px; font-size:18px; font-weight:600;">New task</h3>
@@ -244,6 +241,31 @@
     <div style="display:flex; justify-content:flex-end; gap:8px;">
       <button id="new-task-cancel" class="btn" style="padding:6px 10px;">Cancel</button>
       <button id="new-task-save" class="btn btn-primary" style="padding:6px 12px;">Save</button>
+    </div>
+  </div>
+</div>
+
+<!-- New subject modal -->
+<div id="new-subject-modal" class="modal-backdrop" style="display:none; position:fixed; inset:0; z-index:9998; align-items:center; justify-content:center;">
+  <div class="modal-card" style="border-radius:12px; padding:20px; width:320px; box-shadow:0 12px 40px rgba(0,0,0,0.25);">
+    <h3 style="margin:0 0 12px; font-size:18px; font-weight:600;">New subject</h3>
+
+    <label style="display:block; font-size:12px; margin-bottom:4px;">Subject name</label>
+    <input id="new-subject-name" type="text" placeholder="e.g. Chemistry" style="width:100%; padding:6px; margin-bottom:10px;">
+
+    <label style="display:block; font-size:12px; margin-bottom:4px;">Color</label>
+    <div id="new-subject-swatches" class="subject-color-swatches" role="group" aria-label="Subject color">
+      <button type="button" class="subject-color-swatch selected" data-color="var(--color-text-info)" style="background:var(--color-text-info)" aria-label="Info"></button>
+      <button type="button" class="subject-color-swatch" data-color="var(--color-text-success)" style="background:var(--color-text-success)" aria-label="Success"></button>
+      <button type="button" class="subject-color-swatch" data-color="var(--color-text-purple)" style="background:var(--color-text-purple)" aria-label="Purple"></button>
+      <button type="button" class="subject-color-swatch" data-color="var(--color-text-warning)" style="background:var(--color-text-warning)" aria-label="Warning"></button>
+      <button type="button" class="subject-color-swatch" data-color="var(--color-text-danger)" style="background:var(--color-text-danger)" aria-label="Danger"></button>
+      <button type="button" class="subject-color-swatch" data-color="var(--color-text-primary)" style="background:var(--color-text-primary)" aria-label="Primary"></button>
+    </div>
+
+    <div style="display:flex; justify-content:flex-end; gap:8px; margin-top:8px;">
+      <button id="new-subject-cancel" class="btn" style="padding:6px 10px;">Cancel</button>
+      <button id="new-subject-save" class="btn btn-primary" style="padding:6px 12px;">Save</button>
     </div>
   </div>
 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -27,10 +27,44 @@ const newTaskNotes = document.getElementById('new-task-notes');
 const newTaskCancel = document.getElementById('new-task-cancel');
 const newTaskSave = document.getElementById('new-task-save');
 
+const newSubjectModal = document.getElementById('new-subject-modal');
+const newSubjectName = document.getElementById('new-subject-name');
+const newSubjectCancel = document.getElementById('new-subject-cancel');
+const newSubjectSave = document.getElementById('new-subject-save');
+const addSubjectBtn = document.getElementById('add-subject-btn');
+const newSubjectSwatches = document.getElementById('new-subject-swatches');
+
 function formatDate(dateStr) {
   if (!dateStr) return 'No Date';
   const d = new Date(dateStr);
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute:'2-digit' });
+}
+
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text == null ? '' : String(text);
+  return div.innerHTML;
+}
+
+function renderSubjectsSidebar() {
+  const container = document.getElementById('subjects-list');
+  if (!container) return;
+
+  if (!store.subjects || store.subjects.length === 0) {
+    container.innerHTML = '';
+    return;
+  }
+
+  const tasks = store.tasks || [];
+  container.innerHTML = store.subjects
+    .map((s) => {
+      const count = tasks.filter(
+        (t) => !t.archived && String(t.subject_id) === String(s.id)
+      ).length;
+      const color = s.color || 'var(--color-text-secondary)';
+      return `<div class="nav-item subject-sidebar-row"><span class="nav-dot" style="background:${color}"></span>${escapeHtml(s.name)}<span class="badge">${count}</span></div>`;
+    })
+    .join('');
 }
 
 async function downloadData() {
@@ -515,6 +549,7 @@ function renderExtraction() {
 store.subscribe(renderTasks);
 store.subscribe(renderExtraction);
 store.subscribe(renderCalendar);
+store.subscribe(renderSubjectsSidebar);
 
 document.addEventListener('DOMContentLoaded', () => {
   store.fetchInitialData();
@@ -559,108 +594,141 @@ document.addEventListener('DOMContentLoaded', () => {
     renderCalendar();
   });
 
+  newTaskBtn.addEventListener('click', () => {
+    if (!store.subjects || store.subjects.length === 0) {
+      alert('Subjects are still loading. Please try again in a moment.');
+      return;
+    }
 
-//NEw Task addition event listeners
-newTaskBtn.addEventListener('click', () => {
-  
-  if (!store.subjects || store.subjects.length === 0) {
-    alert('Subjects are still loading. Please try again in a moment.');
-    return;
-  }
+    newTaskSubject.innerHTML = store.subjects
+      .map((s) => `<option value="${escapeHtml(s.id)}">${escapeHtml(s.name)}</option>`)
+      .join('');
 
-  newTaskSubject.innerHTML = store.subjects
-    .map(s => `<option value="${s.id}">${s.name}</option>`)
-    .join('');
+    if (selectedDate) {
+      const d = new Date(selectedDate);
+      d.setHours(18, 0, 0, 0);
+      newTaskDate.value = d.toISOString().substring(0, 16);
+    } else {
+      newTaskDate.value = '';
+    }
 
+    newTaskTitle.value = '';
+    newTaskNotes.value = '';
 
-  if (selectedDate) {
-    const d = new Date(selectedDate);
-    d.setHours(18, 0, 0, 0); 
-    newTaskDate.value = d.toISOString().substring(0, 16);
-  } else {
-    newTaskDate.value = '';
-  }
+    newTaskModal.style.display = 'flex';
+  });
 
-  newTaskTitle.value = '';
-  newTaskNotes.value = '';
-
-  newTaskModal.style.display = 'flex';
-});
-
-newTaskCancel.addEventListener('click', () => {
-  newTaskModal.style.display = 'none';
-});
-
-newTaskModal.addEventListener('click', (e) => {
-  if (e.target === newTaskModal) {
+  newTaskCancel.addEventListener('click', () => {
     newTaskModal.style.display = 'none';
+  });
+
+  newTaskModal.addEventListener('click', (e) => {
+    if (e.target === newTaskModal) {
+      newTaskModal.style.display = 'none';
+    }
+  });
+
+  newTaskSave.addEventListener('click', async () => {
+    const title = newTaskTitle.value.trim();
+    const subject_id = newTaskSubject.value;
+    const notes = newTaskNotes.value.trim();
+    const dateVal = newTaskDate.value;
+
+    if (!title) {
+      alert('Please enter a task name');
+      return;
+    }
+
+    const due_at = dateVal ? new Date(dateVal).toISOString() : '';
+
+    const newTask = {
+      title,
+      subject_id,
+      due_at,
+      notes,
+      priority: 'medium',
+      status: 'Not Started',
+      archived: 0
+    };
+
+    await store.addTasks([newTask]);
+    newTaskModal.style.display = 'none';
+  });
+
+  function resetNewSubjectModal() {
+    newSubjectName.value = '';
+    newSubjectSwatches.querySelectorAll('.subject-color-swatch').forEach((btn, i) => {
+      btn.classList.toggle('selected', i === 0);
+    });
   }
-});
 
-newTaskSave.addEventListener('click', async () => {
-  const title = newTaskTitle.value.trim();
-  const subject_id = newTaskSubject.value;
-  const notes = newTaskNotes.value.trim();
-  const dateVal = newTaskDate.value;
-
-  if (!title) {
-    alert('Please enter a task name');
-    return;
+  function getSelectedSubjectColor() {
+    const sel = newSubjectSwatches.querySelector('.subject-color-swatch.selected');
+    return sel?.dataset.color || 'var(--color-text-info)';
   }
 
-  const due_at = dateVal ? new Date(dateVal).toISOString() : '';
+  newSubjectSwatches.addEventListener('click', (e) => {
+    const btn = e.target.closest('.subject-color-swatch');
+    if (!btn || !newSubjectSwatches.contains(btn)) return;
+    newSubjectSwatches.querySelectorAll('.subject-color-swatch').forEach((b) => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  });
 
-  const newTask = {
-    title,
-    subject_id,
-    due_at,
-    notes,
-    priority: 'medium',
-    status: 'Not Started',
-    archived: 0
-  };
+  addSubjectBtn.addEventListener('click', () => {
+    resetNewSubjectModal();
+    newSubjectModal.style.display = 'flex';
+  });
 
-  await store.addTasks([newTask]);
-  newTaskModal.style.display = 'none';
-});
+  newSubjectCancel.addEventListener('click', () => {
+    newSubjectModal.style.display = 'none';
+  });
 
-addItemsBtn.addEventListener('click', () => {
-  if (store.currentPaste) {
-    store.addTasks(store.currentPaste);
-    store.clearExtracted();
+  newSubjectModal.addEventListener('click', (e) => {
+    if (e.target === newSubjectModal) {
+      newSubjectModal.style.display = 'none';
+    }
+  });
+
+  newSubjectSave.addEventListener('click', async () => {
+    const name = newSubjectName.value.trim();
+    if (!name) {
+      alert('Please enter a subject name');
+      return;
+    }
+    const color = getSelectedSubjectColor();
+    const ok = await store.addSubject({ name, color });
+    if (ok) newSubjectModal.style.display = 'none';
+  });
+
+  extractBtn.addEventListener('click', async () => {
+    const text = pasteInput.value;
+    if (!text.trim()) return;
+
+    extractBtn.innerHTML = '<span class="loader-spinner"></span>';
+    extractBtn.disabled = true;
+
+    const items = await extractTasksFromText(text);
+
+    extractBtn.innerHTML = 'Extract with AI →';
+    extractBtn.disabled = false;
+
+    store.setExtracted(items);
+  });
+
+  clearBtn.addEventListener('click', () => {
     pasteInput.value = '';
-  }
-});
-});
-
-extractBtn.addEventListener('click', async () => {
-  const text = pasteInput.value;
-  if (!text.trim()) return;
-  
-  extractBtn.innerHTML = '<span class="loader-spinner"></span>';
-  extractBtn.disabled = true;
-  
-  const items = await extractTasksFromText(text);
-  
-  extractBtn.innerHTML = 'Extract with AI →';
-  extractBtn.disabled = false;
-  
-  store.setExtracted(items);
-});
-
-clearBtn.addEventListener('click', () => {
-  pasteInput.value = '';
-  store.clearExtracted();
-});
-
-addItemsBtn.addEventListener('click', () => {
-  if (store.currentPaste) {
-    store.addTasks(store.currentPaste);
     store.clearExtracted();
-    pasteInput.value = '';
-  }
-});
+  });
 
-downloadBtn.addEventListener('click', () => {
-  downloadData();
+  addItemsBtn.addEventListener('click', () => {
+    if (store.currentPaste) {
+      store.addTasks(store.currentPaste);
+      store.clearExtracted();
+      pasteInput.value = '';
+    }
+  });
+
+  downloadBtn.addEventListener('click', () => {
+    downloadData();
+  });
 });

--- a/js/store.js
+++ b/js/store.js
@@ -34,6 +34,31 @@ export const store = {
     }
   },
 
+  async addSubject({ name, color }) {
+    try {
+      const res = await fetch('/api/subjects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, color })
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        alert(data.message || 'Failed to add subject');
+        return false;
+      }
+
+      const subsRes = await fetch('/api/subjects');
+      this.subjects = await subsRes.json();
+      this.notify();
+      return true;
+    } catch (e) {
+      console.error('Failed to add subject', e);
+      alert('Network error. Please try again.');
+      return false;
+    }
+  },
+
   // ================= UPDATED FUNCTION =================
   async addTasks(newTasks) {
     try {

--- a/server.js
+++ b/server.js
@@ -232,15 +232,81 @@ function nlpExtractTasksFromText(text) {
 
 // ============================================================
 
-// ============== CSV Download Router ==============
-app.use('/api', csvDownloadRouter);
-
 // ================= SUBJECTS =================
+function deriveSubjectShortCode(name) {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 'SUB';
+  if (words.length === 1) {
+    const w = words[0].replace(/[^a-zA-Z0-9]/g, '');
+    return (w.slice(0, 8).toUpperCase() || 'SUB');
+  }
+  let initials = words
+    .map((w) => w.replace(/[^a-zA-Z0-9]/g, '').charAt(0))
+    .join('')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase();
+  if (initials.length > 8) initials = initials.slice(0, 8);
+  if (initials.length >= 2) return initials;
+  const w = words[0].replace(/[^a-zA-Z0-9]/g, '');
+  return (w.slice(0, 8).toUpperCase() || 'SUB');
+}
+
 app.get('/api/subjects', (req, res) => {
   db.all('SELECT * FROM subjects', (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });
+});
+
+const ALLOWED_SUBJECT_COLORS = new Set([
+  'var(--color-text-info)',
+  'var(--color-text-success)',
+  'var(--color-text-purple)',
+  'var(--color-text-warning)',
+  'var(--color-text-danger)',
+  'var(--color-text-primary)',
+]);
+
+app.post('/api/subjects', (req, res) => {
+  const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+  const color = typeof req.body?.color === 'string' ? req.body.color.trim() : '';
+  if (!name || !color) {
+    return res.status(400).json({ success: false, message: 'Name and color are required' });
+  }
+  if (!ALLOWED_SUBJECT_COLORS.has(color)) {
+    return res.status(400).json({ success: false, message: 'Invalid color' });
+  }
+
+  db.get(
+    'SELECT id FROM subjects WHERE LOWER(TRIM(name)) = LOWER(?)',
+    [name],
+    (err, row) => {
+      if (err) return res.status(500).json({ success: false, message: err.message });
+      if (row) {
+        return res.status(409).json({ success: false, message: 'A subject with this name already exists' });
+      }
+
+      const id = 'sub_' + Date.now() + Math.random().toString(36).substr(2, 5);
+      const short_code = deriveSubjectShortCode(name);
+
+      db.run(
+        'INSERT INTO subjects (id, name, short_code, color) VALUES (?, ?, ?, ?)',
+        [id, name, short_code, color],
+        function (insertErr) {
+          if (insertErr) return res.status(500).json({ success: false, message: insertErr.message });
+          db.get('SELECT * FROM subjects WHERE id = ?', [id], (e2, created) => {
+            if (e2 || !created) {
+              return res.status(500).json({
+                success: false,
+                message: e2?.message || 'Failed to load created subject'
+              });
+            }
+            res.status(201).json(created);
+          });
+        }
+      );
+    }
+  );
 });
 
 // ================= TASKS =================
@@ -443,6 +509,9 @@ app.post('/api/auth/login', (req, res) => {
   }
   res.json({ success: true, email: user.email });
 });
+
+// CSV download (mounted after other /api routes so it does not shadow them)
+app.use('/api', csvDownloadRouter);
 
 // Intentional test route for verifying server error page behavior.
 app.get('/debug/force-error', (req, res, next) => {


### PR DESCRIPTION
Fixes #2

### Problem
Clicking "Add subject" in the sidebar did not open any UI or persist new subjects.

### Solution
- Modal for subject name + color choice (palette aligned with existing CSS variable tokens stored in the DB).
- Click handler on `#add-subject-btn`.
- `POST /api/subjects` with name/color validation, duplicate-name handling (`409`), and server-derived `short_code`.
- `store.addSubject` plus refetch of `/api/subjects` and a dynamic sidebar (`#subjects-list`) with per-subject badges counting non-archived tasks.
- CSV download router mounted after other `/api` routes so API handlers are not shadowed by the generic `/api` 404 handler.
- Event listeners consolidated under a single `DOMContentLoaded` callback.

### How to test
1. Run `npm install`, then `node server.js`.
2. Open the app → Subjects → Add subject → enter name and color → Save.
3. Confirm the subject appears in the sidebar and in the "New task" subject dropdown.