### PR TITLE
fix: add subject creation with modal, API endpoint, and CSV router order

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -631,7 +631,8 @@ body {
 /* Task Addition Model */
 
 
-#new-task-modal{
+#new-task-modal,
+#new-subject-modal {
 
   position: fixed;
   inset: 0;
@@ -643,7 +644,8 @@ body {
 }
 
 
-#new-task-modal .modal-card {
+#new-task-modal .modal-card,
+#new-subject-modal .modal-card {
   width: 100%;
   max-width: 360px;
   background-color: #0f172a;                     
@@ -656,7 +658,8 @@ body {
 }
 
 
-#new-task-modal .modal-card h3 {
+#new-task-modal .modal-card h3,
+#new-subject-modal .modal-card h3 {
   margin: 0 0 12px;
   font-size: 18px;
   font-weight: 600;
@@ -665,7 +668,8 @@ body {
 }
 
 
-#new-task-modal label {
+#new-task-modal label,
+#new-subject-modal label {
   display: block;
   font-size: 11px;
   font-weight: 600;
@@ -677,7 +681,9 @@ body {
 
 
 #new-task-modal input,
-#new-task-modal select {
+#new-task-modal select,
+#new-subject-modal input,
+#new-subject-modal select {
   width: 100%;
   box-sizing: border-box;
   font-size: 13px;
@@ -692,13 +698,16 @@ body {
 }
 
 
-#new-task-modal input::placeholder {
+#new-task-modal input::placeholder,
+#new-subject-modal input::placeholder {
   color: #6b7280;
 }
 
 
 #new-task-modal input:focus,
-#new-task-modal select:focus {
+#new-task-modal select:focus,
+#new-subject-modal input:focus,
+#new-subject-modal select:focus {
   outline: none;
   border-color: #4f46e5;
   box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35);
@@ -706,7 +715,8 @@ body {
 }
 
 
-#new-task-modal .modal-card > div:last-child {
+#new-task-modal .modal-card > div:last-child,
+#new-subject-modal .modal-card > div:last-child {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -714,19 +724,22 @@ body {
 }
 
 
-#new-task-modal .btn {
+#new-task-modal .btn,
+#new-subject-modal .btn {
   font-size: 12px;
   padding: 6px 10px;
   border-radius: 999px;
 }
 
-#new-task-modal .btn:not(.btn-primary) {
+#new-task-modal .btn:not(.btn-primary),
+#new-subject-modal .btn:not(.btn-primary) {
   background: rgba(15, 23, 42, 0.9);
   color: #e5e7eb;
   border: 1px solid #4b5563;
 }
 
-#new-task-modal .btn:not(.btn-primary):hover {
+#new-task-modal .btn:not(.btn-primary):hover,
+#new-subject-modal .btn:not(.btn-primary):hover {
   background: #020617;
 }
 
@@ -748,8 +761,36 @@ body {
 
 
 @media (max-width: 480px) {
-  #new-task-modal .modal-card {
+  #new-task-modal .modal-card,
+  #new-subject-modal .modal-card {
     max-width: 90vw;
     padding: 16px 14px 12px;
   }
+}
+
+#new-subject-modal .subject-color-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+#new-subject-modal .subject-color-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+#new-subject-modal .subject-color-swatch:hover {
+  transform: scale(1.06);
+}
+
+#new-subject-modal .subject-color-swatch--selected {
+  box-shadow: 0 0 0 2px #0f172a, 0 0 0 4px #a5b4fc;
 }

--- a/index.html
+++ b/index.html
@@ -84,11 +84,8 @@
       </div>
       <div class="sidebar-divider"></div>
       <div class="sidebar-header">Subjects</div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-info)"></span>Computer Science<span class="badge">3</span></div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-success)"></span>Mathematics<span class="badge">2</span></div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-purple)"></span>English Lit<span class="badge">1</span></div>
-      <div class="nav-item"><span class="nav-dot" style="background:var(--color-text-warning)"></span>Physics<span class="badge">1</span></div>
-      <div class="add-subject">
+      <div id="subjects-sidebar-list"></div>
+      <div class="add-subject" id="add-subject-btn" role="button" tabindex="0">
         <svg width="14" height="14" fill="none"><path d="M7 1v12M1 7h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg> Add subject
       </div>
     </div>
@@ -269,8 +266,20 @@
   }
 </script>
 
+<div id="new-subject-modal" class="modal-backdrop" style="display:none; position:fixed; inset:0; z-index:9998; align-items:center; justify-content:center;">
+  <div class="modal-card" style="border-radius:12px; padding:20px; width:320px; box-shadow:0 12px 40px rgba(0,0,0,0.25);">
+    <h3 style="margin:0 0 12px; font-size:18px; font-weight:600;">New subject</h3>
+    <label style="display:block; font-size:12px; margin-bottom:4px;">Subject name</label>
+    <input id="new-subject-name" type="text" style="width:100%; padding:6px; margin-bottom:12px;" placeholder="e.g. History">
+    <label style="display:block; font-size:12px; margin-bottom:6px;">Color</label>
+    <div id="new-subject-colors" class="subject-color-swatches"></div>
+    <div style="display:flex; justify-content:flex-end; gap:8px; margin-top:16px;">
+      <button id="new-subject-cancel" class="btn" style="padding:6px 10px;">Cancel</button>
+      <button id="new-subject-save" class="btn btn-primary" style="padding:6px 12px;">Save</button>
+    </div>
+  </div>
+</div>
 
-//ADD TASK MODEL
 <div id="new-task-modal" class="modal-backdrop" style="display:none; position:fixed; inset:0;  z-index:9998; align-items:center; justify-content:center;">
   <div class="modal-card" style=" border-radius:12px; padding:20px; width:320px; box-shadow:0 12px 40px rgba(0,0,0,0.25);">
     <h3 style="margin:0 0 12px; font-size:18px; font-weight:600;">New task</h3>

--- a/js/app.js
+++ b/js/app.js
@@ -20,6 +20,75 @@ const newTaskBtn = document.getElementById('add-task-btn');
 
 
 
+const SUBJECT_COLORS = [
+  'var(--color-text-info)',
+  'var(--color-text-success)',
+  'var(--color-text-purple)',
+  'var(--color-text-warning)',
+  'var(--color-text-danger)',
+  'var(--color-text-secondary)',
+];
+
+let selectedNewSubjectColor = SUBJECT_COLORS[0];
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const newSubjectModal = document.getElementById('new-subject-modal');
+const newSubjectName = document.getElementById('new-subject-name');
+const newSubjectColorsEl = document.getElementById('new-subject-colors');
+const newSubjectCancel = document.getElementById('new-subject-cancel');
+const newSubjectSave = document.getElementById('new-subject-save');
+const addSubjectBtn = document.getElementById('add-subject-btn');
+
+function syncNewSubjectColorSwatches() {
+  if (!newSubjectColorsEl) return;
+  newSubjectColorsEl.querySelectorAll('.subject-color-swatch').forEach(btn => {
+    const on = btn.dataset.color === selectedNewSubjectColor;
+    btn.classList.toggle('subject-color-swatch--selected', on);
+    btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+  });
+}
+
+function openNewSubjectModal() {
+  if (!newSubjectModal || !newSubjectName) return;
+  newSubjectName.value = '';
+  selectedNewSubjectColor = SUBJECT_COLORS[0];
+  syncNewSubjectColorSwatches();
+  newSubjectModal.style.display = 'flex';
+  newSubjectName.focus();
+}
+
+function renderSidebarSubjects() {
+  const listEl = document.getElementById('subjects-sidebar-list');
+  if (!listEl) return;
+
+  const subjects = store.subjects;
+  const tasks = store.tasks;
+
+  const countBySubject = {};
+  subjects.forEach(s => {
+    countBySubject[s.id] = 0;
+  });
+  tasks.forEach(t => {
+    if (t.archived || !t.subject_id || countBySubject[t.subject_id] === undefined) return;
+    countBySubject[t.subject_id]++;
+  });
+
+  listEl.innerHTML = subjects.map(s => {
+    const n = countBySubject[s.id] ?? 0;
+    const safeColor = s.color ? escapeHtml(s.color) : 'var(--color-text-info)';
+    return `<div class="nav-item subject-sidebar-item" data-subject-id="${escapeHtml(s.id)}">
+      <span class="nav-dot" style="background:${safeColor}"></span>${escapeHtml(s.name)}<span class="badge">${n}</span>
+    </div>`;
+  }).join('');
+}
+
 const newTaskModal = document.getElementById('new-task-modal');
 const newTaskSubject = document.getElementById('new-task-subject');
 const newTaskTitle = document.getElementById('new-task-title');
@@ -172,9 +241,9 @@ function renderFocusTasks() {
     focusTaskList.innerHTML = dueSoon.map(t => {
       const sub = subjects.find(s => s.id === t.subject_id) || subjects[0] || { short_code: 'Gen' };
       let pillClass = '';
-      if(sub.code === 'CS') pillClass = 'pill-blue';
-      else if(sub.code === 'Maths') pillClass = 'pill-green';
-      else if(sub.code === 'English') pillClass = 'pill-purple';
+      if(sub.short_code === 'CS') pillClass = 'pill-blue';
+      else if(sub.short_code === 'Maths') pillClass = 'pill-green';
+      else if(sub.short_code === 'English') pillClass = 'pill-purple';
       else pillClass = 'pill-amber';
       
       return `
@@ -343,9 +412,9 @@ function renderTasks() {
       const isDone = t.status === 'Done';
       
       let pillClass = '';
-      if(sub.code === 'CS') pillClass = 'pill-blue';
-      else if(sub.code === 'Maths') pillClass = 'pill-green';
-      else if(sub.code === 'English') pillClass = 'pill-purple';
+      if(sub.short_code === 'CS') pillClass = 'pill-blue';
+      else if(sub.short_code === 'Maths') pillClass = 'pill-green';
+      else if(sub.short_code === 'English') pillClass = 'pill-purple';
       else pillClass = 'pill-amber';
       
       if (t._isEditing) {
@@ -727,8 +796,63 @@ store.subscribe(renderTasks);
 store.subscribe(renderExtraction);
 store.subscribe(renderCalendar);
 store.subscribe(renderFocusTasks);
+store.subscribe(renderSidebarSubjects);
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (newSubjectColorsEl) {
+    SUBJECT_COLORS.forEach(c => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'subject-color-swatch';
+      btn.dataset.color = c;
+      btn.style.background = c;
+      btn.addEventListener('click', () => {
+        selectedNewSubjectColor = c;
+        syncNewSubjectColorSwatches();
+      });
+      newSubjectColorsEl.appendChild(btn);
+    });
+    syncNewSubjectColorSwatches();
+  }
+
+  if (addSubjectBtn) {
+    addSubjectBtn.addEventListener('click', () => openNewSubjectModal());
+    addSubjectBtn.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openNewSubjectModal();
+      }
+    });
+  }
+
+  if (newSubjectCancel) {
+    newSubjectCancel.addEventListener('click', () => {
+      if (newSubjectModal) newSubjectModal.style.display = 'none';
+    });
+  }
+
+  if (newSubjectModal) {
+    newSubjectModal.addEventListener('click', (e) => {
+      if (e.target === newSubjectModal) newSubjectModal.style.display = 'none';
+    });
+  }
+
+  if (newSubjectSave) {
+    newSubjectSave.addEventListener('click', async () => {
+      const ok = await store.addSubject({ name: newSubjectName.value, color: selectedNewSubjectColor });
+      if (ok && newSubjectModal) newSubjectModal.style.display = 'none';
+    });
+  }
+
+  if (newSubjectName) {
+    newSubjectName.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        newSubjectSave?.click();
+      }
+    });
+  }
+
   store.fetchInitialData();
   
   const calendarBtn = document.getElementById('calendar-btn');

--- a/js/store.js
+++ b/js/store.js
@@ -34,6 +34,34 @@ export const store = {
     }
   },
 
+  async addSubject({ name, color }) {
+    const trimmed = String(name || '').trim();
+    if (!trimmed) {
+      alert('Please enter a subject name');
+      return false;
+    }
+    try {
+      const res = await fetch('/api/subjects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed, color: color || 'var(--color-text-info)' })
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alert(data.error || 'Failed to add subject');
+        return false;
+      }
+      const subsRes = await fetch('/api/subjects');
+      this.subjects = await subsRes.json();
+      this.notify();
+      return true;
+    } catch (e) {
+      console.error('Failed to add subject', e);
+      alert('Network error. Please try again.');
+      return false;
+    }
+  },
+
   // ================= UPDATED FUNCTION =================
   async addTasks(newTasks) {
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,6 +1659,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",

--- a/server.js
+++ b/server.js
@@ -232,15 +232,42 @@ function nlpExtractTasksFromText(text) {
 
 // ============================================================
 
-// ============== CSV Download Router ==============
-app.use('/api', csvDownloadRouter);
-
 // ================= SUBJECTS =================
 app.get('/api/subjects', (req, res) => {
   db.all('SELECT * FROM subjects', (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });
+});
+
+const ALLOWED_SUBJECT_COLORS = new Set([
+  'var(--color-text-info)',
+  'var(--color-text-success)',
+  'var(--color-text-purple)',
+  'var(--color-text-warning)',
+  'var(--color-text-danger)',
+  'var(--color-text-secondary)',
+]);
+
+app.post('/api/subjects', (req, res) => {
+  const name = String(req.body?.name || '').trim();
+  let color = String(req.body?.color || '').trim() || 'var(--color-text-info)';
+  if (!name) {
+    return res.status(400).json({ error: 'Subject name is required' });
+  }
+  if (!ALLOWED_SUBJECT_COLORS.has(color)) {
+    color = 'var(--color-text-info)';
+  }
+  const shortCode = name.replace(/[^a-zA-Z0-9]/g, '').toUpperCase().slice(0, 4) || 'SUB';
+  const id = `sub_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+  db.run(
+    'INSERT INTO subjects (id, name, short_code, color) VALUES (?, ?, ?, ?)',
+    [id, name, shortCode, color],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.status(201).json({ id, name, short_code: shortCode, color });
+    }
+  );
 });
 
 // ================= TASKS =================
@@ -448,6 +475,8 @@ app.post('/api/auth/login', (req, res) => {
 app.get('/debug/force-error', (req, res, next) => {
   next(new Error('Intentional test error'));
 });
+
+app.use('/api', csvDownloadRouter);
 
 app.use('/api', (req, res) => {
   return res.status(404).json({ error: 'API route not found' });


### PR DESCRIPTION
Summary

- Implements Add subject in the sidebar: users can open a modal, enter a subject name, pick a theme color, and persist the subject via the API. The subject list in the sidebar is driven from the database (with per-subject task counts for non-archived tasks) instead of static HTML.

- Adds POST /api/subjects with server-side validation of allowed CSS variable color tokens, auto-generated short_code, and a unique id, inserting into SQLite.

- Fixes Express route ordering: the CSV download router is mounted after all explicit /api/* handlers so routes such as POST /api/subjects (and other API routes registered on app) are no longer unreachable behind the early /api middleware / 404 behavior.

- Corrects task pill styling to use short_code from the API/DB instead of a non-existent code property.

How to test:

1. Load the app, open Subjects in the sidebar → + Add subject → enter name, choose color → Save; confirm the new subject appears and badges reflect non-archived task counts.
2. Open New task (or edit a task) and confirm the new subject appears in the subject dropdown.
3. Optional: POST /api/subjects with { "name": "…", "color": "var(--color-text-info)" } returns 201; empty name returns 400.

Notes:

- package-lock.json: updated as part of the local npm install workflow; adjust or drop from the PR if the maintainer prefers a minimal diff.