### PR TITLE
fix: dark mode for summary-box card

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1,5 +1,11 @@
 /* css/index.css */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 :root {
   --color-background-primary: #ffffff;
@@ -8,40 +14,42 @@
   --color-text-primary: #1a1a18;
   --color-text-secondary: #6b6b66;
   --color-text-tertiary: #9c9a92;
-  --color-border-tertiary: rgba(0,0,0,0.08); /* softer */
-  --color-border-secondary: rgba(0,0,0,0.15); /* softer */
-  --color-border-primary: rgba(0,0,0,0.30);
-  
+  --color-border-tertiary: rgba(0, 0, 0, 0.08);
+  /* softer */
+  --color-border-secondary: rgba(0, 0, 0, 0.15);
+  /* softer */
+  --color-border-primary: rgba(0, 0, 0, 0.30);
+
   --color-danger-rgb: 163, 45, 45;
   --color-info-rgb: 24, 95, 165;
   --color-success-rgb: 22, 101, 52;
-  
+
   --color-text-danger: #a32d2d;
   --color-background-danger: #fcebeb;
   --color-border-danger: rgba(var(--color-danger-rgb), 0.35);
-  
+
   --color-text-info: #185fa5;
   --color-background-info: #e6f1fb;
   --color-border-info: rgba(var(--color-info-rgb), 0.35);
-  
+
   --color-text-success: #166534;
   --color-background-success: #eaf3de;
   --color-border-success: rgba(var(--color-success-rgb), 0.35);
 
   --color-text-warning: #854f0b;
   --color-background-warning: #faeeda;
-  
+
   --color-text-purple: #3c3489;
   --color-background-purple: #eeedfe;
-  
+
   --border-radius-sm: 6px;
   --border-radius-md: 10px;
   --border-radius-lg: 16px;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  
-  --shadow-sm: 0 2px 8px rgba(0,0,0,0.04);
-  --shadow-md: 0 4px 16px rgba(0,0,0,0.06);
-  --shadow-lg: 0 8px 32px rgba(0,0,0,0.08);
+
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.08);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -52,20 +60,20 @@
     --color-text-primary: #efede5;
     --color-text-secondary: #a3a198;
     --color-text-tertiary: #73726c;
-    --color-border-tertiary: rgba(255,255,255,0.06);
-    --color-border-secondary: rgba(255,255,255,0.12);
-    --color-border-primary: rgba(255,255,255,0.22);
+    --color-border-tertiary: rgba(255, 255, 255, 0.06);
+    --color-border-secondary: rgba(255, 255, 255, 0.12);
+    --color-border-primary: rgba(255, 255, 255, 0.22);
     --color-text-danger: #fc9c9c;
     --color-background-danger: rgba(252, 156, 156, 0.15);
-    --color-border-danger: rgba(252,156,156,0.3);
-    
+    --color-border-danger: rgba(252, 156, 156, 0.3);
+
     --color-text-info: #9ecdfc;
     --color-background-info: rgba(158, 205, 252, 0.15);
-    --color-border-info: rgba(158,205,252,0.3);
-    
+    --color-border-info: rgba(158, 205, 252, 0.3);
+
     --color-text-success: #a0d45a;
     --color-background-success: rgba(160, 212, 90, 0.15);
-    --color-border-success: rgba(160,212,90,0.3);
+    --color-border-success: rgba(160, 212, 90, 0.3);
 
     --color-text-warning: #fab35e;
     --color-background-warning: rgba(250, 179, 94, 0.15);
@@ -89,14 +97,43 @@ body {
 }
 
 /* Animations */
-@keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
-@keyframes popIn { 0% { transform: scale(0.95); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
 
-.wrapper { width: 100%; max-width: 1200px; animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes popIn {
+  0% {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.wrapper {
+  width: 100%;
+  max-width: 1200px;
+  animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
 
 .label {
-  font-size: 12px; font-weight: 600; color: var(--color-text-tertiary);
-  letter-spacing: .08em; margin-bottom: 12px; text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  letter-spacing: .08em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
 }
 
 .app {
@@ -113,59 +150,317 @@ body {
 
 /* Sidebar */
 .sidebar {
-  background: var(--color-background-secondary); border-right: 1px solid var(--color-border-tertiary);
-  padding: 20px 16px; display: flex; flex-direction: column; gap: 4px;
+  background: var(--color-background-secondary);
+  border-right: 1px solid var(--color-border-tertiary);
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
-.sidebar-header { font-size: 11px; font-weight: 700; color: var(--color-text-tertiary); padding: 8px 12px; margin-bottom: 2px; letter-spacing: .06em; text-transform: uppercase; }
-.nav-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--border-radius-md); cursor: pointer; font-size: 14px; font-weight: 500; color: var(--color-text-secondary); transition: all 0.2s ease; position: relative; }
-.nav-item:hover { background: var(--color-background-primary); color: var(--color-text-primary); transform: translateX(2px); }
-.nav-item.active { background: var(--color-background-primary); color: var(--color-text-primary); box-shadow: var(--shadow-sm); }
-.nav-item.active::before { content: ''; position: absolute; left: 0; top: 15%; height: 70%; width: 3px; background: var(--color-text-primary); border-radius: 4px; }
-.nav-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1); }
-.badge { margin-left: auto; font-size: 12px; font-weight: 600; background: var(--color-background-tertiary); color: var(--color-text-secondary); padding: 2px 8px; border-radius: 12px; transition: all 0.2s; }
-.nav-item:hover .badge { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); }
-.sidebar-divider { height: 1px; background: var(--color-border-tertiary); margin: 12px 0; }
-.add-subject { font-size: 13px; font-weight: 500; color: var(--color-text-tertiary); padding: 8px 12px; cursor: pointer; transition: color 0.2s; display: flex; align-items: center; gap: 8px; }
-.add-subject:hover { color: var(--color-text-primary); }
+
+.sidebar-header {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  padding: 8px 12px;
+  margin-bottom: 2px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.nav-item:hover {
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  transform: translateX(2px);
+}
+
+.nav-item.active {
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 15%;
+  height: 70%;
+  width: 3px;
+  background: var(--color-text-primary);
+  border-radius: 4px;
+}
+
+.nav-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.badge {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--color-background-tertiary);
+  color: var(--color-text-secondary);
+  padding: 2px 8px;
+  border-radius: 12px;
+  transition: all 0.2s;
+}
+
+.nav-item:hover .badge {
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-tertiary);
+}
+
+.sidebar-divider {
+  height: 1px;
+  background: var(--color-border-tertiary);
+  margin: 12px 0;
+}
+
+.add-subject {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-subject:hover {
+  color: var(--color-text-primary);
+}
 
 /* Main */
-.main { display: flex; flex-direction: column; overflow: hidden; position: relative; }
-.topbar { display: flex; align-items: center; gap: 12px; padding: 16px 24px; border-bottom: 1px solid var(--color-border-tertiary); flex-shrink: 0; background: rgba(var(--color-background-primary), 0.8); backdrop-filter: blur(10px); z-index: 10; }
-.topbar-title { font-size: 18px; font-weight: 600; color: var(--color-text-primary); flex: 1; }
-.btn { font-family: inherit; font-size: 13px; font-weight: 600; padding: 8px 16px; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); background: var(--color-background-primary); color: var(--color-text-primary); cursor: pointer; transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: var(--shadow-sm); display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
-.btn:hover { background: var(--color-background-secondary); transform: translateY(-1px); box-shadow: var(--shadow-md); }
-.btn:active { transform: translateY(0); box-shadow: 0 0 0; }
-.btn-primary { background: var(--color-text-primary); color: var(--color-background-primary); border-color: transparent; }
-.btn-primary:hover { background: var(--color-text-secondary); }
+.main {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  flex-shrink: 0;
+  background: rgba(var(--color-background-primary), 0.8);
+  backdrop-filter: blur(10px);
+  z-index: 10;
+}
+
+.topbar-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+
+.btn {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: var(--shadow-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.btn:hover {
+  background: var(--color-background-secondary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn:active {
+  transform: translateY(0);
+  box-shadow: 0 0 0;
+}
+
+.btn-primary {
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  border-color: transparent;
+}
+
+.btn-primary:hover {
+  background: var(--color-text-secondary);
+}
 
 /* Calendar */
-.cal-section { padding: 16px 24px; border-bottom: 1px solid var(--color-border-tertiary); flex-shrink: 0; }
-.cal-header { display: flex; align-items: center; margin-bottom: 16px; }
-.cal-title { font-size: 15px; font-weight: 600; flex: 1; color: var(--color-text-primary); }
-.cal-nav { font-size: 18px; color: var(--color-text-secondary); cursor: pointer; padding: 4px 8px; border-radius: 4px; transition: background 0.2s; }
-.cal-nav:hover { background: var(--color-background-secondary); color: var(--color-text-primary); }
-.cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; text-align: center; }
-.cal-day-label { font-size: 11px; color: var(--color-text-tertiary); padding-bottom: 8px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
-.cal-day { font-size: 13px; font-weight: 500; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: var(--border-radius-md); cursor: pointer; color: var(--color-text-secondary); position: relative; transition: all 0.2s; }
-.cal-day:hover { background: var(--color-background-secondary); color: var(--color-text-primary); transform: scale(1.1); z-index: 1; }
-.cal-day.today { background: var(--color-text-primary); color: var(--color-background-primary); box-shadow: var(--shadow-sm); }
-.cal-day-indicators { position: absolute; bottom: 3px; left: 0; right: 0; display: flex; justify-content: center; gap: 3px; }
-.cal-day-indicator { width: 5px; height: 5px; border-radius: 50%; }
-.cal-day.muted { color: var(--color-border-secondary); }
-.cal-legend { display: flex; gap: 16px; margin-top: 16px; font-size: 11px; font-weight: 500; color: var(--color-text-tertiary); justify-content: flex-end; }
-.cal-legend span { display: flex; align-items: center; gap: 6px; }
-.legend-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.cal-section {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  flex-shrink: 0;
+}
+
+.cal-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.cal-title {
+  font-size: 15px;
+  font-weight: 600;
+  flex: 1;
+  color: var(--color-text-primary);
+}
+
+.cal-nav {
+  font-size: 18px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.cal-nav:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+}
+
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  text-align: center;
+}
+
+.cal-day-label {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  padding-bottom: 8px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cal-day {
+  font-size: 13px;
+  font-weight: 500;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  position: relative;
+  transition: all 0.2s;
+}
+
+.cal-day:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+  transform: scale(1.1);
+  z-index: 1;
+}
+
+.cal-day.today {
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.cal-day-indicators {
+  position: absolute;
+  bottom: 3px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 3px;
+}
+
+.cal-day-indicator {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+}
+
+.cal-day.muted {
+  color: var(--color-border-secondary);
+}
+
+.cal-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  justify-content: flex-end;
+}
+
+.cal-legend span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
 
 /* Tasks */
-.tasks-section { flex: 1; overflow-y: auto; padding: 0 24px 24px; scroll-behavior: smooth; }
-.tasks-section::-webkit-scrollbar { width: 6px; }
-.tasks-section::-webkit-scrollbar-thumb { background: var(--color-border-secondary); border-radius: 10px; }
+.tasks-section {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 24px 24px;
+  scroll-behavior: smooth;
+}
+
+.tasks-section::-webkit-scrollbar {
+  width: 6px;
+}
+
+.tasks-section::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 10px;
+}
+
 .tasks-actions-bar {
   margin-top: 18px;
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
 }
+
 .task-action-btn {
   border: 1px solid var(--color-border-success);
   background: var(--color-background-success);
@@ -177,21 +472,25 @@ body {
   cursor: pointer;
   transition: all 0.2s ease;
 }
+
 .task-action-btn:hover {
   filter: brightness(0.98);
   transform: translateY(-1px);
 }
+
 .task-action-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
   filter: none;
 }
+
 .task-action-btn-secondary {
   border-color: var(--color-border-info);
   background: var(--color-background-info);
   color: var(--color-text-info);
 }
+
 .tasks-empty-state {
   margin-top: 14px;
   padding: 14px;
@@ -201,37 +500,175 @@ body {
   font-size: 13px;
   background: var(--color-background-secondary);
 }
-.tasks-group { margin-top: 24px; animation: fadeIn 0.4s ease forwards; }
-.tasks-group-header { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.tasks-group-header span { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.tasks-group {
+  margin-top: 24px;
+  animation: fadeIn 0.4s ease forwards;
+}
+
+.tasks-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tasks-group-header span {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
 
 .task-item {
-  display: flex; align-items: flex-start; gap: 14px; padding: 12px 14px;
-  border-radius: var(--border-radius-md); cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1px solid transparent; background: var(--color-background-primary);
+  border: 1px solid transparent;
+  background: var(--color-background-primary);
   margin-bottom: 6px;
   border: 1px solid var(--color-border-tertiary);
 }
-.task-item:hover { background: var(--color-background-secondary); transform: translateX(4px); border-color: var(--color-border-secondary); box-shadow: var(--shadow-sm); }
-.task-item.urgent { border-color: var(--color-border-danger); background: linear-gradient(to right, var(--color-background-danger) 0%, var(--color-background-primary) 100%); }
-.task-check { width: 18px; height: 18px; border-radius: 5px; border: 2px solid var(--color-border-secondary); flex-shrink: 0; margin-top: 2px; transition: all 0.2s; position: relative; cursor: pointer; }
-.task-check:hover { border-color: var(--color-text-primary); }
-.task-check.done { background: var(--color-text-success); border-color: var(--color-text-success); }
-.task-check.done::after { content: ''; position: absolute; left: 4px; top: 1px; width: 4px; height: 8px; border: solid white; border-width: 0 2px 2px 0; transform: rotate(45deg); }
-.task-info { flex: 1; min-width: 0; }
-.task-name { font-size: 14px; font-weight: 500; color: var(--color-text-primary); line-height: 1.4; transition: color 0.2s; margin-bottom: 6px; }
-.task-item.done .task-name { text-decoration: line-through; color: var(--color-text-tertiary); }
-.task-meta { font-size: 12px; color: var(--color-text-tertiary); margin-top: 6px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; font-weight: 500; }
-.task-pill { font-size: 11px; padding: 2px 8px; border-radius: 12px; font-weight: 600; display: inline-flex; align-items: center; gap: 4px; border: 1px solid transparent; }
-.pill-red  { background: var(--color-background-danger); color: var(--color-text-danger); border-color: var(--color-border-danger); }
-.pill-blue { background: var(--color-background-info); color: var(--color-text-info); border-color: var(--color-border-info); }
-.pill-green{ background: var(--color-background-success); color: var(--color-text-success); border-color: var(--color-border-success); }
-.pill-amber{ background: var(--color-background-warning); color: var(--color-text-warning); border-color: rgba(133, 79, 11, 0.2); }
-.pill-purple{ background: var(--color-background-purple); color: var(--color-text-purple); border-color: rgba(60, 52, 137, 0.2); }
 
-.conflict-card { font-size: 13px; font-weight: 500; color: var(--color-text-warning); background: var(--color-background-warning); border: 1px solid rgba(133, 79, 11, 0.3); border-radius: var(--border-radius-md); padding: 12px 16px; line-height: 1.5; display: flex; gap: 12px; align-items: flex-start; box-shadow: var(--shadow-sm); }
-.conflict-icon { font-size: 18px; line-height: 1; }
+.task-item:hover {
+  background: var(--color-background-secondary);
+  transform: translateX(4px);
+  border-color: var(--color-border-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.task-item.urgent {
+  border-color: var(--color-border-danger);
+  background: linear-gradient(to right, var(--color-background-danger) 0%, var(--color-background-primary) 100%);
+}
+
+.task-check {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 2px solid var(--color-border-secondary);
+  flex-shrink: 0;
+  margin-top: 2px;
+  transition: all 0.2s;
+  position: relative;
+  cursor: pointer;
+}
+
+.task-check:hover {
+  border-color: var(--color-text-primary);
+}
+
+.task-check.done {
+  background: var(--color-text-success);
+  border-color: var(--color-text-success);
+}
+
+.task-check.done::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 4px;
+  height: 8px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.task-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  line-height: 1.4;
+  transition: color 0.2s;
+  margin-bottom: 6px;
+}
+
+.task-item.done .task-name {
+  text-decoration: line-through;
+  color: var(--color-text-tertiary);
+}
+
+.task-meta {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  margin-top: 6px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-weight: 500;
+}
+
+.task-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+}
+
+.pill-red {
+  background: var(--color-background-danger);
+  color: var(--color-text-danger);
+  border-color: var(--color-border-danger);
+}
+
+.pill-blue {
+  background: var(--color-background-info);
+  color: var(--color-text-info);
+  border-color: var(--color-border-info);
+}
+
+.pill-green {
+  background: var(--color-background-success);
+  color: var(--color-text-success);
+  border-color: var(--color-border-success);
+}
+
+.pill-amber {
+  background: var(--color-background-warning);
+  color: var(--color-text-warning);
+  border-color: rgba(133, 79, 11, 0.2);
+}
+
+.pill-purple {
+  background: var(--color-background-purple);
+  color: var(--color-text-purple);
+  border-color: rgba(60, 52, 137, 0.2);
+}
+
+.conflict-card {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-warning);
+  background: var(--color-background-warning);
+  border: 1px solid rgba(133, 79, 11, 0.3);
+  border-radius: var(--border-radius-md);
+  padding: 12px 16px;
+  line-height: 1.5;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  box-shadow: var(--shadow-sm);
+}
+
+.conflict-icon {
+  font-size: 18px;
+  line-height: 1;
+}
 
 .task-actions {
   display: flex;
@@ -239,9 +676,11 @@ body {
   opacity: 0;
   transition: opacity 0.2s;
 }
+
 .task-item:hover .task-actions {
   opacity: 1;
 }
+
 .task-btn {
   padding: 4px 8px;
   border-radius: 4px;
@@ -253,16 +692,19 @@ body {
   color: var(--color-text-secondary);
   transition: all 0.2s;
 }
+
 .task-btn:hover {
   background: var(--color-background-secondary);
   color: var(--color-text-primary);
   border-color: var(--color-border-primary);
 }
+
 .task-btn-danger:hover {
   background: var(--color-background-danger);
   color: var(--color-text-danger);
   border-color: var(--color-text-danger);
 }
+
 .task-btn-info:hover {
   background: var(--color-background-info);
   color: var(--color-text-info);
@@ -270,84 +712,382 @@ body {
 }
 
 /* Right Panel */
-.panel { border-left: 1px solid var(--color-border-tertiary); display: flex; flex-direction: column; background: var(--color-background-secondary); overflow: hidden; }
-.panel.panel-collapsed { overflow: visible; }
+.panel {
+  border-left: 1px solid var(--color-border-tertiary);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-background-secondary);
+  overflow: hidden;
+}
+
+.panel.panel-collapsed {
+  overflow: visible;
+}
+
 .panel.panel-collapsed .panel-title,
 .panel.panel-collapsed .panel-subtitle,
 .panel.panel-collapsed .paste-zone,
 .panel.panel-collapsed .paste-actions,
 .panel.panel-collapsed .extract-preview,
-.panel.panel-collapsed .add-btn { display: none; }
-.panel-header { padding: 20px 24px 16px; border-bottom: 1px solid var(--color-border-tertiary); background: var(--color-background-primary); flex-shrink: 0; display: flex; align-items: flex-start; gap: 10px; }
-.panel.panel-collapsed .panel-header { padding: 12px; justify-content: center; border-bottom: none; }
-.panel-toggle-btn { flex-shrink: 0; background: none; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--color-text-secondary); transition: all 0.2s; margin-top: 2px; }
-.panel-toggle-btn:hover { background: var(--color-background-secondary); color: var(--color-text-primary); }
-.panel-toggle-icon { transition: transform 0.3s cubic-bezier(0.4,0,0.2,1); }
-.panel-title { font-size: 16px; font-weight: 600; color: var(--color-text-primary); display: flex; align-items: center; gap: 8px; }
-.panel-title svg { opacity: 0.8; }
-.panel-subtitle { font-size: 12px; font-weight: 500; color: var(--color-text-tertiary); margin-top: 4px; }
+.panel.panel-collapsed .add-btn {
+  display: none;
+}
 
-.paste-zone { margin: 20px 20px 12px; border: 2px dashed var(--color-border-secondary); border-radius: var(--border-radius-lg); padding: 24px 20px; text-align: center; cursor: text; transition: all 0.2s; background: var(--color-background-primary); display: flex; flex-direction: column; align-items: center; justify-content: center; position: relative; min-height: 120px; overflow: hidden; }
-.paste-zone:hover { border-color: var(--color-text-info); background: var(--color-background-info); }
-.paste-zone:focus-within { border-color: var(--color-text-primary); border-style: solid; box-shadow: inset 0 0 0 1px var(--color-text-primary); outline: none; }
-.paste-icon { font-size: 24px; margin-bottom: 8px; color: var(--color-text-secondary); transition: color 0.2s; }
-.paste-zone:hover .paste-icon { color: var(--color-text-info); }
+.panel-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  background: var(--color-background-primary);
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.panel.panel-collapsed .panel-header {
+  padding: 12px;
+  justify-content: center;
+  border-bottom: none;
+}
+
+.panel-toggle-btn {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  transition: all 0.2s;
+  margin-top: 2px;
+}
+
+.panel-toggle-btn:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+}
+
+.panel-toggle-icon {
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.panel-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panel-title svg {
+  opacity: 0.8;
+}
+
+.panel-subtitle {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  margin-top: 4px;
+}
+
+.paste-zone {
+  margin: 20px 20px 12px;
+  border: 2px dashed var(--color-border-secondary);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 20px;
+  text-align: center;
+  cursor: text;
+  transition: all 0.2s;
+  background: var(--color-background-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  min-height: 120px;
+  overflow: hidden;
+}
+
+.paste-zone:hover {
+  border-color: var(--color-text-info);
+  background: var(--color-background-info);
+}
+
+.paste-zone:focus-within {
+  border-color: var(--color-text-primary);
+  border-style: solid;
+  box-shadow: inset 0 0 0 1px var(--color-text-primary);
+  outline: none;
+}
+
+.paste-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+  color: var(--color-text-secondary);
+  transition: color 0.2s;
+}
+
+.paste-zone:hover .paste-icon {
+  color: var(--color-text-info);
+}
 
 .paste-input {
-  position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-  width: 100%; height: 100%; opacity: 0; resize: none; border: none; padding: 20px; font-family: inherit; font-size: 13px; z-index: 2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  resize: none;
+  border: none;
+  padding: 20px;
+  font-family: inherit;
+  font-size: 13px;
+  z-index: 2;
 }
-.paste-input:focus, .paste-input:not(:placeholder-shown) { opacity: 1; z-index: 10; background: var(--color-background-primary); color: var(--color-text-primary); outline: none; }
-.paste-label { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 4px; pointer-events: none; }
-.paste-hint { font-size: 12px; color: var(--color-text-tertiary); line-height: 1.5; pointer-events: none; }
 
-.paste-actions { padding: 0 20px 16px; display: flex; gap: 12px; }
+.paste-input:focus,
+.paste-input:not(:placeholder-shown) {
+  opacity: 1;
+  z-index: 10;
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  outline: none;
+}
 
-.extract-preview { flex: 1; overflow-y: auto; padding: 0 20px 20px; scroll-behavior: smooth; }
-.extract-preview::-webkit-scrollbar { width: 6px; }
-.extract-preview::-webkit-scrollbar-thumb { background: var(--color-border-secondary); border-radius: 10px; }
-.extract-title { font-size: 11px; font-weight: 700; color: var(--color-text-tertiary); margin-bottom: 12px; letter-spacing: .06em; text-transform: uppercase; display: flex; align-items: center; justify-content: space-between; }
+.paste-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 4px;
+  pointer-events: none;
+}
 
-.extract-card { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); border-radius: var(--border-radius-md); padding: 14px 16px; margin-bottom: 12px; box-shadow: var(--shadow-sm); animation: popIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; transform-origin: center; position: relative; overflow: hidden; }
-.extract-subject { font-size: 11px; font-weight: 700; margin-bottom: 6px; letter-spacing: .04em; text-transform: uppercase; }
-.extract-task-name { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; line-height: 1.4; }
-.extract-row { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 500; color: var(--color-text-secondary); margin-top: 4px; }
-.extract-icon { font-size: 14px; }
-.conf-bar { height: 4px; border-radius: 2px; margin-top: 12px; background: var(--color-border-tertiary); overflow: hidden; }
-.conf-fill { height: 100%; border-radius: 2px; transition: width 1s cubic-bezier(0.16, 1, 0.3, 1); }
-.conf-label { font-size: 11px; font-weight: 600; color: var(--color-text-tertiary); margin-top: 6px; display: flex; justify-content: space-between; }
-.conf-edit { color: var(--color-text-info); cursor: pointer; transition: color 0.2s; }
-.conf-edit:hover { color: var(--color-text-primary); }
+.paste-hint {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  line-height: 1.5;
+  pointer-events: none;
+}
 
-.add-btn { margin: 0 20px 20px; padding: 12px; border: none; border-radius: var(--border-radius-md); background: var(--color-text-primary); color: var(--color-background-primary); font-size: 14px; font-weight: 600; cursor: pointer; text-align: center; flex-shrink: 0; box-shadow: 0 4px 12px rgba(0,0,0,0.15); transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
-.add-btn:hover:not(:disabled) { background: var(--color-text-secondary); transform: translateY(-2px); box-shadow: 0 6px 16px rgba(0,0,0,0.2); }
-.add-btn:active:not(:disabled) { transform: translateY(0); box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
-.add-btn:disabled { background: var(--color-border-secondary); cursor: not-allowed; transform: none; box-shadow: none; color: var(--color-text-tertiary); }
+.paste-actions {
+  padding: 0 20px 16px;
+  display: flex;
+  gap: 12px;
+}
+
+.extract-preview {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 20px 20px;
+  scroll-behavior: smooth;
+}
+
+.extract-preview::-webkit-scrollbar {
+  width: 6px;
+}
+
+.extract-preview::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 10px;
+}
+
+.extract-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  margin-bottom: 12px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.extract-card {
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-md);
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  box-shadow: var(--shadow-sm);
+  animation: popIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  transform-origin: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.extract-subject {
+  font-size: 11px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.extract-task-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.extract-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+}
+
+.extract-icon {
+  font-size: 14px;
+}
+
+.conf-bar {
+  height: 4px;
+  border-radius: 2px;
+  margin-top: 12px;
+  background: var(--color-border-tertiary);
+  overflow: hidden;
+}
+
+.conf-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 1s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.conf-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  margin-top: 6px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.conf-edit {
+  color: var(--color-text-info);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.conf-edit:hover {
+  color: var(--color-text-primary);
+}
+
+.add-btn {
+  margin: 0 20px 20px;
+  padding: 12px;
+  border: none;
+  border-radius: var(--border-radius-md);
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.add-btn:hover:not(:disabled) {
+  background: var(--color-text-secondary);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.add-btn:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.add-btn:disabled {
+  background: var(--color-border-secondary);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  color: var(--color-text-tertiary);
+}
 
 /* Loader */
 .loader-spinner {
   display: inline-block;
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0,0,0,0.1);
+  border: 2px solid rgba(0, 0, 0, 0.1);
   border-radius: 50%;
   border-top-color: var(--color-text-primary);
   animation: spin 0.8s linear infinite;
 }
+
 @media (prefers-color-scheme: dark) {
-  .loader-spinner { border-color: rgba(255,255,255,0.1); border-top-color: #fff; }
+  .loader-spinner {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-top-color: #fff;
+  }
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* Utility classes */
-.hidden { display: none !important; }
+.hidden {
+  display: none !important;
+}
 
 /* Timer duration input */
-.timer-duration-row { display: flex; align-items: center; gap: 10px; }
-.timer-duration-label { font-size: 12px; font-weight: 600; color: var(--color-text-tertiary); text-transform: uppercase; letter-spacing: 0.05em; }
-.timer-duration-input { width: 64px; padding: 6px 10px; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); background: var(--color-background-primary); color: var(--color-text-primary); font-size: 14px; font-weight: 600; font-family: inherit; text-align: center; transition: border-color 0.2s; }
-.timer-duration-input:focus { outline: none; border-color: var(--color-text-primary); }
-.timer-duration-input:disabled { opacity: 0.5; cursor: not-allowed; }
+.timer-duration-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.timer-duration-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.timer-duration-input {
+  width: 64px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  text-align: center;
+  transition: border-color 0.2s;
+}
+
+.timer-duration-input:focus {
+  outline: none;
+  border-color: var(--color-text-primary);
+}
+
+.timer-duration-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 /* Focus Mode */
 .focus-section {
@@ -358,12 +1098,14 @@ body {
   overflow-y: auto;
   gap: 32px;
 }
+
 .focus-dashboard {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 24px;
 }
+
 .timer-container {
   position: relative;
   width: 240px;
@@ -372,6 +1114,7 @@ body {
   align-items: center;
   justify-content: center;
 }
+
 .timer-svg {
   position: absolute;
   top: 0;
@@ -380,11 +1123,13 @@ body {
   height: 100%;
   transform: rotate(-90deg);
 }
+
 .timer-path-elapsed {
   fill: none;
   stroke: var(--color-border-tertiary);
   stroke-width: 4;
 }
+
 .timer-path-remaining {
   fill: none;
   stroke: var(--color-text-primary);
@@ -392,6 +1137,7 @@ body {
   stroke-linecap: round;
   transition: stroke-dashoffset 1s linear;
 }
+
 .timer-text {
   font-size: 48px;
   font-weight: 700;
@@ -400,15 +1146,19 @@ body {
   letter-spacing: -0.02em;
   z-index: 1;
 }
+
 .timer-controls {
   display: flex;
   gap: 12px;
 }
-.focus-task-container, .focus-task-selector {
+
+.focus-task-container,
+.focus-task-selector {
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
 }
+
 .focus-task-header {
   font-size: 13px;
   font-weight: 600;
@@ -417,6 +1167,7 @@ body {
   letter-spacing: 0.05em;
   margin-bottom: 12px;
 }
+
 .active-focus-task {
   background: var(--color-background-primary);
   border: 1px solid var(--color-border-primary);
@@ -428,16 +1179,19 @@ body {
   align-items: center;
   justify-content: center;
 }
+
 .no-task-selected {
   color: var(--color-text-secondary);
   font-size: 14px;
   font-weight: 500;
 }
+
 .focus-task-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
+
 .focus-task-item {
   display: flex;
   align-items: center;
@@ -449,11 +1203,13 @@ body {
   cursor: pointer;
   transition: all 0.2s;
 }
+
 .focus-task-item:hover {
   background: var(--color-background-secondary);
   border-color: var(--color-text-info);
   transform: translateY(-1px);
 }
+
 .focus-task-item .task-name {
   margin-bottom: 0;
   flex: 1;
@@ -640,7 +1396,7 @@ body {
   display: none;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.55) !important; 
+  background-color: rgba(0, 0, 0, 0.55) !important;
 }
 
 
@@ -648,13 +1404,13 @@ body {
 #new-subject-modal .modal-card {
   width: 100%;
   max-width: 360px;
-  background-color: #0f172a;                     
+  background-color: #0f172a;
   border-radius: 14px;
   padding: 20px 20px 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6) !important;
-  color: #e5e7eb;                        
+  color: #e5e7eb;
   box-sizing: border-box;
-  border: 1px solid rgba(148, 163, 184, 0.35)  !important;
+  border: 1px solid rgba(148, 163, 184, 0.35) !important;
 }
 
 
@@ -675,7 +1431,8 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #9ca3af; /* muted */
+  color: #9ca3af;
+  /* muted */
   margin-bottom: 4px;
 }
 
@@ -690,11 +1447,11 @@ body {
   padding: 7px 8px;
   margin-bottom: 10px;
   border-radius: 6px;
-  border: 1px solid #4b5563;              
-  background-color: #111827 !important;                  
+  border: 1px solid #4b5563;
+  background-color: #111827 !important;
   color: #e5e7eb;
   transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  color-scheme: dark;                      
+  color-scheme: dark;
 }
 
 
@@ -711,12 +1468,12 @@ body {
   outline: none;
   border-color: #4f46e5;
   box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35);
-  background: #020617;                     
+  background: #020617;
 }
 
 
-#new-task-modal .modal-card > div:last-child,
-#new-subject-modal .modal-card > div:last-child {
+#new-task-modal .modal-card>div:last-child,
+#new-subject-modal .modal-card>div:last-child {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -753,6 +1510,7 @@ body {
     opacity: 0;
     transform: translateY(6px) scale(0.97);
   }
+
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
@@ -761,6 +1519,7 @@ body {
 
 
 @media (max-width: 480px) {
+
   #new-task-modal .modal-card,
   #new-subject-modal .modal-card {
     max-width: 90vw;
@@ -794,8 +1553,15 @@ body {
 #new-subject-modal .subject-color-swatch--selected {
   box-shadow: 0 0 0 2px #0f172a, 0 0 0 4px #a5b4fc;
 }
+
 /* css/index.css */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 :root {
   --color-background-primary: #ffffff;
@@ -804,40 +1570,42 @@ body {
   --color-text-primary: #1a1a18;
   --color-text-secondary: #6b6b66;
   --color-text-tertiary: #9c9a92;
-  --color-border-tertiary: rgba(0,0,0,0.08); /* softer */
-  --color-border-secondary: rgba(0,0,0,0.15); /* softer */
-  --color-border-primary: rgba(0,0,0,0.30);
-  
+  --color-border-tertiary: rgba(0, 0, 0, 0.08);
+  /* softer */
+  --color-border-secondary: rgba(0, 0, 0, 0.15);
+  /* softer */
+  --color-border-primary: rgba(0, 0, 0, 0.30);
+
   --color-danger-rgb: 163, 45, 45;
   --color-info-rgb: 24, 95, 165;
   --color-success-rgb: 22, 101, 52;
-  
+
   --color-text-danger: #a32d2d;
   --color-background-danger: #fcebeb;
   --color-border-danger: rgba(var(--color-danger-rgb), 0.35);
-  
+
   --color-text-info: #185fa5;
   --color-background-info: #e6f1fb;
   --color-border-info: rgba(var(--color-info-rgb), 0.35);
-  
+
   --color-text-success: #166534;
   --color-background-success: #eaf3de;
   --color-border-success: rgba(var(--color-success-rgb), 0.35);
 
   --color-text-warning: #854f0b;
   --color-background-warning: #faeeda;
-  
+
   --color-text-purple: #3c3489;
   --color-background-purple: #eeedfe;
-  
+
   --border-radius-sm: 6px;
   --border-radius-md: 10px;
   --border-radius-lg: 16px;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  
-  --shadow-sm: 0 2px 8px rgba(0,0,0,0.04);
-  --shadow-md: 0 4px 16px rgba(0,0,0,0.06);
-  --shadow-lg: 0 8px 32px rgba(0,0,0,0.08);
+
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.08);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -848,20 +1616,20 @@ body {
     --color-text-primary: #efede5;
     --color-text-secondary: #a3a198;
     --color-text-tertiary: #73726c;
-    --color-border-tertiary: rgba(255,255,255,0.06);
-    --color-border-secondary: rgba(255,255,255,0.12);
-    --color-border-primary: rgba(255,255,255,0.22);
+    --color-border-tertiary: rgba(255, 255, 255, 0.06);
+    --color-border-secondary: rgba(255, 255, 255, 0.12);
+    --color-border-primary: rgba(255, 255, 255, 0.22);
     --color-text-danger: #fc9c9c;
     --color-background-danger: rgba(252, 156, 156, 0.15);
-    --color-border-danger: rgba(252,156,156,0.3);
-    
+    --color-border-danger: rgba(252, 156, 156, 0.3);
+
     --color-text-info: #9ecdfc;
     --color-background-info: rgba(158, 205, 252, 0.15);
-    --color-border-info: rgba(158,205,252,0.3);
-    
+    --color-border-info: rgba(158, 205, 252, 0.3);
+
     --color-text-success: #a0d45a;
     --color-background-success: rgba(160, 212, 90, 0.15);
-    --color-border-success: rgba(160,212,90,0.3);
+    --color-border-success: rgba(160, 212, 90, 0.3);
 
     --color-text-warning: #fab35e;
     --color-background-warning: rgba(250, 179, 94, 0.15);
@@ -878,20 +1646,20 @@ body {
   --color-text-primary: #efede5;
   --color-text-secondary: #a3a198;
   --color-text-tertiary: #73726c;
-  --color-border-tertiary: rgba(255,255,255,0.06);
-  --color-border-secondary: rgba(255,255,255,0.12);
-  --color-border-primary: rgba(255,255,255,0.22);
+  --color-border-tertiary: rgba(255, 255, 255, 0.06);
+  --color-border-secondary: rgba(255, 255, 255, 0.12);
+  --color-border-primary: rgba(255, 255, 255, 0.22);
   --color-text-danger: #fc9c9c;
   --color-background-danger: rgba(252, 156, 156, 0.15);
-  --color-border-danger: rgba(252,156,156,0.3);
-  
+  --color-border-danger: rgba(252, 156, 156, 0.3);
+
   --color-text-info: #9ecdfc;
   --color-background-info: rgba(158, 205, 252, 0.15);
-  --color-border-info: rgba(158,205,252,0.3);
-  
+  --color-border-info: rgba(158, 205, 252, 0.3);
+
   --color-text-success: #a0d45a;
   --color-background-success: rgba(160, 212, 90, 0.15);
-  --color-border-success: rgba(160,212,90,0.3);
+  --color-border-success: rgba(160, 212, 90, 0.3);
 
   --color-text-warning: #fab35e;
   --color-background-warning: rgba(250, 179, 94, 0.15);
@@ -907,25 +1675,25 @@ body {
   --color-text-primary: #1a1a18;
   --color-text-secondary: #6b6b66;
   --color-text-tertiary: #9c9a92;
-  --color-border-tertiary: rgba(0,0,0,0.08); 
-  --color-border-secondary: rgba(0,0,0,0.15); 
-  --color-border-primary: rgba(0,0,0,0.30);
-  
+  --color-border-tertiary: rgba(0, 0, 0, 0.08);
+  --color-border-secondary: rgba(0, 0, 0, 0.15);
+  --color-border-primary: rgba(0, 0, 0, 0.30);
+
   --color-text-danger: #a32d2d;
   --color-background-danger: #fcebeb;
   --color-border-danger: rgba(163, 45, 45, 0.35);
-  
+
   --color-text-info: #185fa5;
   --color-background-info: #e6f1fb;
   --color-border-info: rgba(24, 95, 165, 0.35);
-  
+
   --color-text-success: #166534;
   --color-background-success: #eaf3de;
   --color-border-success: rgba(22, 101, 52, 0.35);
 
   --color-text-warning: #854f0b;
   --color-background-warning: #faeeda;
-  
+
   --color-text-purple: #3c3489;
   --color-background-purple: #eeedfe;
 }
@@ -944,14 +1712,43 @@ body {
 }
 
 /* Animations */
-@keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
-@keyframes popIn { 0% { transform: scale(0.95); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
 
-.wrapper { width: 100%; max-width: 1200px; animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes popIn {
+  0% {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.wrapper {
+  width: 100%;
+  max-width: 1200px;
+  animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
 
 .label {
-  font-size: 12px; font-weight: 600; color: var(--color-text-tertiary);
-  letter-spacing: .08em; margin-bottom: 12px; text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  letter-spacing: .08em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
 }
 
 .app {
@@ -968,59 +1765,317 @@ body {
 
 /* Sidebar */
 .sidebar {
-  background: var(--color-background-secondary); border-right: 1px solid var(--color-border-tertiary);
-  padding: 20px 16px; display: flex; flex-direction: column; gap: 4px;
+  background: var(--color-background-secondary);
+  border-right: 1px solid var(--color-border-tertiary);
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
-.sidebar-header { font-size: 11px; font-weight: 700; color: var(--color-text-tertiary); padding: 8px 12px; margin-bottom: 2px; letter-spacing: .06em; text-transform: uppercase; }
-.nav-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--border-radius-md); cursor: pointer; font-size: 14px; font-weight: 500; color: var(--color-text-secondary); transition: all 0.2s ease; position: relative; }
-.nav-item:hover { background: var(--color-background-primary); color: var(--color-text-primary); transform: translateX(2px); }
-.nav-item.active { background: var(--color-background-primary); color: var(--color-text-primary); box-shadow: var(--shadow-sm); }
-.nav-item.active::before { content: ''; position: absolute; left: 0; top: 15%; height: 70%; width: 3px; background: var(--color-text-primary); border-radius: 4px; }
-.nav-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1); }
-.badge { margin-left: auto; font-size: 12px; font-weight: 600; background: var(--color-background-tertiary); color: var(--color-text-secondary); padding: 2px 8px; border-radius: 12px; transition: all 0.2s; }
-.nav-item:hover .badge { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); }
-.sidebar-divider { height: 1px; background: var(--color-border-tertiary); margin: 12px 0; }
-.add-subject { font-size: 13px; font-weight: 500; color: var(--color-text-tertiary); padding: 8px 12px; cursor: pointer; transition: color 0.2s; display: flex; align-items: center; gap: 8px; }
-.add-subject:hover { color: var(--color-text-primary); }
+
+.sidebar-header {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  padding: 8px 12px;
+  margin-bottom: 2px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.nav-item:hover {
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  transform: translateX(2px);
+}
+
+.nav-item.active {
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 15%;
+  height: 70%;
+  width: 3px;
+  background: var(--color-text-primary);
+  border-radius: 4px;
+}
+
+.nav-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.badge {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--color-background-tertiary);
+  color: var(--color-text-secondary);
+  padding: 2px 8px;
+  border-radius: 12px;
+  transition: all 0.2s;
+}
+
+.nav-item:hover .badge {
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-tertiary);
+}
+
+.sidebar-divider {
+  height: 1px;
+  background: var(--color-border-tertiary);
+  margin: 12px 0;
+}
+
+.add-subject {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-subject:hover {
+  color: var(--color-text-primary);
+}
 
 /* Main */
-.main { display: flex; flex-direction: column; overflow: hidden; position: relative; }
-.topbar { display: flex; align-items: center; gap: 12px; padding: 16px 24px; border-bottom: 1px solid var(--color-border-tertiary); flex-shrink: 0; background: rgba(var(--color-background-primary), 0.8); backdrop-filter: blur(10px); z-index: 10; }
-.topbar-title { font-size: 18px; font-weight: 600; color: var(--color-text-primary); flex: 1; }
-.btn { font-family: inherit; font-size: 13px; font-weight: 600; padding: 8px 16px; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); background: var(--color-background-primary); color: var(--color-text-primary); cursor: pointer; transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: var(--shadow-sm); display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
-.btn:hover { background: var(--color-background-secondary); transform: translateY(-1px); box-shadow: var(--shadow-md); }
-.btn:active { transform: translateY(0); box-shadow: 0 0 0; }
-.btn-primary { background: var(--color-text-primary); color: var(--color-background-primary); border-color: transparent; }
-.btn-primary:hover { background: var(--color-text-secondary); }
+.main {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  flex-shrink: 0;
+  background: rgba(var(--color-background-primary), 0.8);
+  backdrop-filter: blur(10px);
+  z-index: 10;
+}
+
+.topbar-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+
+.btn {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: var(--shadow-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.btn:hover {
+  background: var(--color-background-secondary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn:active {
+  transform: translateY(0);
+  box-shadow: 0 0 0;
+}
+
+.btn-primary {
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  border-color: transparent;
+}
+
+.btn-primary:hover {
+  background: var(--color-text-secondary);
+}
 
 /* Calendar */
-.cal-section { padding: 16px 24px; border-bottom: 1px solid var(--color-border-tertiary); flex-shrink: 0; }
-.cal-header { display: flex; align-items: center; margin-bottom: 16px; }
-.cal-title { font-size: 15px; font-weight: 600; flex: 1; color: var(--color-text-primary); }
-.cal-nav { font-size: 18px; color: var(--color-text-secondary); cursor: pointer; padding: 4px 8px; border-radius: 4px; transition: background 0.2s; }
-.cal-nav:hover { background: var(--color-background-secondary); color: var(--color-text-primary); }
-.cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; text-align: center; }
-.cal-day-label { font-size: 11px; color: var(--color-text-tertiary); padding-bottom: 8px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
-.cal-day { font-size: 13px; font-weight: 500; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: var(--border-radius-md); cursor: pointer; color: var(--color-text-secondary); position: relative; transition: all 0.2s; }
-.cal-day:hover { background: var(--color-background-secondary); color: var(--color-text-primary); transform: scale(1.1); z-index: 1; }
-.cal-day.today { background: var(--color-text-primary); color: var(--color-background-primary); box-shadow: var(--shadow-sm); }
-.cal-day-indicators { position: absolute; bottom: 3px; left: 0; right: 0; display: flex; justify-content: center; gap: 3px; }
-.cal-day-indicator { width: 5px; height: 5px; border-radius: 50%; }
-.cal-day.muted { color: var(--color-border-secondary); }
-.cal-legend { display: flex; gap: 16px; margin-top: 16px; font-size: 11px; font-weight: 500; color: var(--color-text-tertiary); justify-content: flex-end; }
-.cal-legend span { display: flex; align-items: center; gap: 6px; }
-.legend-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.cal-section {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  flex-shrink: 0;
+}
+
+.cal-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.cal-title {
+  font-size: 15px;
+  font-weight: 600;
+  flex: 1;
+  color: var(--color-text-primary);
+}
+
+.cal-nav {
+  font-size: 18px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.cal-nav:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+}
+
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  text-align: center;
+}
+
+.cal-day-label {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  padding-bottom: 8px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cal-day {
+  font-size: 13px;
+  font-weight: 500;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  position: relative;
+  transition: all 0.2s;
+}
+
+.cal-day:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+  transform: scale(1.1);
+  z-index: 1;
+}
+
+.cal-day.today {
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.cal-day-indicators {
+  position: absolute;
+  bottom: 3px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 3px;
+}
+
+.cal-day-indicator {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+}
+
+.cal-day.muted {
+  color: var(--color-border-secondary);
+}
+
+.cal-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  justify-content: flex-end;
+}
+
+.cal-legend span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
 
 /* Tasks */
-.tasks-section { flex: 1; overflow-y: auto; padding: 0 24px 24px; scroll-behavior: smooth; }
-.tasks-section::-webkit-scrollbar { width: 6px; }
-.tasks-section::-webkit-scrollbar-thumb { background: var(--color-border-secondary); border-radius: 10px; }
+.tasks-section {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 24px 24px;
+  scroll-behavior: smooth;
+}
+
+.tasks-section::-webkit-scrollbar {
+  width: 6px;
+}
+
+.tasks-section::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 10px;
+}
+
 .tasks-actions-bar {
   margin-top: 18px;
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
 }
+
 .task-action-btn {
   border: 1px solid var(--color-border-success);
   background: var(--color-background-success);
@@ -1032,21 +2087,25 @@ body {
   cursor: pointer;
   transition: all 0.2s ease;
 }
+
 .task-action-btn:hover {
   filter: brightness(0.98);
   transform: translateY(-1px);
 }
+
 .task-action-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
   filter: none;
 }
+
 .task-action-btn-secondary {
   border-color: var(--color-border-info);
   background: var(--color-background-info);
   color: var(--color-text-info);
 }
+
 .tasks-empty-state {
   margin-top: 14px;
   padding: 14px;
@@ -1056,37 +2115,175 @@ body {
   font-size: 13px;
   background: var(--color-background-secondary);
 }
-.tasks-group { margin-top: 24px; animation: fadeIn 0.4s ease forwards; }
-.tasks-group-header { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.tasks-group-header span { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.tasks-group {
+  margin-top: 24px;
+  animation: fadeIn 0.4s ease forwards;
+}
+
+.tasks-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tasks-group-header span {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
 
 .task-item {
-  display: flex; align-items: flex-start; gap: 14px; padding: 12px 14px;
-  border-radius: var(--border-radius-md); cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1px solid transparent; background: var(--color-background-primary);
+  border: 1px solid transparent;
+  background: var(--color-background-primary);
   margin-bottom: 6px;
   border: 1px solid var(--color-border-tertiary);
 }
-.task-item:hover { background: var(--color-background-secondary); transform: translateX(4px); border-color: var(--color-border-secondary); box-shadow: var(--shadow-sm); }
-.task-item.urgent { border-color: var(--color-border-danger); background: linear-gradient(to right, var(--color-background-danger) 0%, var(--color-background-primary) 100%); }
-.task-check { width: 18px; height: 18px; border-radius: 5px; border: 2px solid var(--color-border-secondary); flex-shrink: 0; margin-top: 2px; transition: all 0.2s; position: relative; cursor: pointer; }
-.task-check:hover { border-color: var(--color-text-primary); }
-.task-check.done { background: var(--color-text-success); border-color: var(--color-text-success); }
-.task-check.done::after { content: ''; position: absolute; left: 4px; top: 1px; width: 4px; height: 8px; border: solid white; border-width: 0 2px 2px 0; transform: rotate(45deg); }
-.task-info { flex: 1; min-width: 0; }
-.task-name { font-size: 14px; font-weight: 500; color: var(--color-text-primary); line-height: 1.4; transition: color 0.2s; margin-bottom: 6px; }
-.task-item.done .task-name { text-decoration: line-through; color: var(--color-text-tertiary); }
-.task-meta { font-size: 12px; color: var(--color-text-tertiary); margin-top: 6px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; font-weight: 500; }
-.task-pill { font-size: 11px; padding: 2px 8px; border-radius: 12px; font-weight: 600; display: inline-flex; align-items: center; gap: 4px; border: 1px solid transparent; }
-.pill-red  { background: var(--color-background-danger); color: var(--color-text-danger); border-color: var(--color-border-danger); }
-.pill-blue { background: var(--color-background-info); color: var(--color-text-info); border-color: var(--color-border-info); }
-.pill-green{ background: var(--color-background-success); color: var(--color-text-success); border-color: var(--color-border-success); }
-.pill-amber{ background: var(--color-background-warning); color: var(--color-text-warning); border-color: rgba(133, 79, 11, 0.2); }
-.pill-purple{ background: var(--color-background-purple); color: var(--color-text-purple); border-color: rgba(60, 52, 137, 0.2); }
 
-.conflict-card { font-size: 13px; font-weight: 500; color: var(--color-text-warning); background: var(--color-background-warning); border: 1px solid rgba(133, 79, 11, 0.3); border-radius: var(--border-radius-md); padding: 12px 16px; line-height: 1.5; display: flex; gap: 12px; align-items: flex-start; box-shadow: var(--shadow-sm); }
-.conflict-icon { font-size: 18px; line-height: 1; }
+.task-item:hover {
+  background: var(--color-background-secondary);
+  transform: translateX(4px);
+  border-color: var(--color-border-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.task-item.urgent {
+  border-color: var(--color-border-danger);
+  background: linear-gradient(to right, var(--color-background-danger) 0%, var(--color-background-primary) 100%);
+}
+
+.task-check {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 2px solid var(--color-border-secondary);
+  flex-shrink: 0;
+  margin-top: 2px;
+  transition: all 0.2s;
+  position: relative;
+  cursor: pointer;
+}
+
+.task-check:hover {
+  border-color: var(--color-text-primary);
+}
+
+.task-check.done {
+  background: var(--color-text-success);
+  border-color: var(--color-text-success);
+}
+
+.task-check.done::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 4px;
+  height: 8px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.task-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  line-height: 1.4;
+  transition: color 0.2s;
+  margin-bottom: 6px;
+}
+
+.task-item.done .task-name {
+  text-decoration: line-through;
+  color: var(--color-text-tertiary);
+}
+
+.task-meta {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  margin-top: 6px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-weight: 500;
+}
+
+.task-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+}
+
+.pill-red {
+  background: var(--color-background-danger);
+  color: var(--color-text-danger);
+  border-color: var(--color-border-danger);
+}
+
+.pill-blue {
+  background: var(--color-background-info);
+  color: var(--color-text-info);
+  border-color: var(--color-border-info);
+}
+
+.pill-green {
+  background: var(--color-background-success);
+  color: var(--color-text-success);
+  border-color: var(--color-border-success);
+}
+
+.pill-amber {
+  background: var(--color-background-warning);
+  color: var(--color-text-warning);
+  border-color: rgba(133, 79, 11, 0.2);
+}
+
+.pill-purple {
+  background: var(--color-background-purple);
+  color: var(--color-text-purple);
+  border-color: rgba(60, 52, 137, 0.2);
+}
+
+.conflict-card {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-warning);
+  background: var(--color-background-warning);
+  border: 1px solid rgba(133, 79, 11, 0.3);
+  border-radius: var(--border-radius-md);
+  padding: 12px 16px;
+  line-height: 1.5;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  box-shadow: var(--shadow-sm);
+}
+
+.conflict-icon {
+  font-size: 18px;
+  line-height: 1;
+}
 
 .task-actions {
   display: flex;
@@ -1094,9 +2291,11 @@ body {
   opacity: 0;
   transition: opacity 0.2s;
 }
+
 .task-item:hover .task-actions {
   opacity: 1;
 }
+
 .task-btn {
   padding: 4px 8px;
   border-radius: 4px;
@@ -1108,16 +2307,19 @@ body {
   color: var(--color-text-secondary);
   transition: all 0.2s;
 }
+
 .task-btn:hover {
   background: var(--color-background-secondary);
   color: var(--color-text-primary);
   border-color: var(--color-border-primary);
 }
+
 .task-btn-danger:hover {
   background: var(--color-background-danger);
   color: var(--color-text-danger);
   border-color: var(--color-text-danger);
 }
+
 .task-btn-info:hover {
   background: var(--color-background-info);
   color: var(--color-text-info);
@@ -1125,77 +2327,307 @@ body {
 }
 
 /* Right Panel */
-.panel { border-left: 1px solid var(--color-border-tertiary); display: flex; flex-direction: column; background: var(--color-background-secondary); overflow: hidden; }
-.panel-header { padding: 20px 24px 16px; border-bottom: 1px solid var(--color-border-tertiary); background: var(--color-background-primary); flex-shrink: 0; }
-.panel-title { font-size: 16px; font-weight: 600; color: var(--color-text-primary); display: flex; align-items: center; gap: 8px; }
-.panel-title svg { opacity: 0.8; }
-.panel-subtitle { font-size: 12px; font-weight: 500; color: var(--color-text-tertiary); margin-top: 4px; }
+.panel {
+  border-left: 1px solid var(--color-border-tertiary);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-background-secondary);
+  overflow: hidden;
+}
 
-.paste-zone { margin: 20px 20px 12px; border: 2px dashed var(--color-border-secondary); border-radius: var(--border-radius-lg); padding: 24px 20px; text-align: center; cursor: text; transition: all 0.2s; background: var(--color-background-primary); display: flex; flex-direction: column; align-items: center; justify-content: center; position: relative; min-height: 120px; overflow: hidden; }
-.paste-zone:hover { border-color: var(--color-text-info); background: var(--color-background-info); }
-.paste-zone:focus-within { border-color: var(--color-text-primary); border-style: solid; box-shadow: inset 0 0 0 1px var(--color-text-primary); outline: none; }
-.paste-icon { font-size: 24px; margin-bottom: 8px; color: var(--color-text-secondary); transition: color 0.2s; }
-.paste-zone:hover .paste-icon { color: var(--color-text-info); }
+.panel-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  background: var(--color-background-primary);
+  flex-shrink: 0;
+}
+
+.panel-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panel-title svg {
+  opacity: 0.8;
+}
+
+.panel-subtitle {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  margin-top: 4px;
+}
+
+.paste-zone {
+  margin: 20px 20px 12px;
+  border: 2px dashed var(--color-border-secondary);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 20px;
+  text-align: center;
+  cursor: text;
+  transition: all 0.2s;
+  background: var(--color-background-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  min-height: 120px;
+  overflow: hidden;
+}
+
+.paste-zone:hover {
+  border-color: var(--color-text-info);
+  background: var(--color-background-info);
+}
+
+.paste-zone:focus-within {
+  border-color: var(--color-text-primary);
+  border-style: solid;
+  box-shadow: inset 0 0 0 1px var(--color-text-primary);
+  outline: none;
+}
+
+.paste-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+  color: var(--color-text-secondary);
+  transition: color 0.2s;
+}
+
+.paste-zone:hover .paste-icon {
+  color: var(--color-text-info);
+}
 
 .paste-input {
-  position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-  width: 100%; height: 100%; opacity: 0; resize: none; border: none; padding: 20px; font-family: inherit; font-size: 13px; z-index: 2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  resize: none;
+  border: none;
+  padding: 20px;
+  font-family: inherit;
+  font-size: 13px;
+  z-index: 2;
 }
 
 .summary-box {
   margin-top: 16px;
   padding: 14px;
-  background: linear-gradient(135deg, #eef2ff, #f8fafc);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.95));
   border-radius: 12px;
   font-size: 14px;
   line-height: 1.6;
-  border: 1px solid #e5e7eb;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-text-primary);
 }
 
-.paste-input:focus, .paste-input:not(:placeholder-shown) { opacity: 1; z-index: 10; background: var(--color-background-primary); color: var(--color-text-primary); outline: none; }
-.paste-label { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 4px; pointer-events: none; }
-.paste-hint { font-size: 12px; color: var(--color-text-tertiary); line-height: 1.5; pointer-events: none; }
+.paste-input:focus,
+.paste-input:not(:placeholder-shown) {
+  opacity: 1;
+  z-index: 10;
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  outline: none;
+}
 
-.paste-actions { padding: 0 20px 16px; display: flex; gap: 12px; }
+.paste-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 4px;
+  pointer-events: none;
+}
 
-.extract-preview { flex: 1; overflow-y: auto; padding: 0 20px 20px; scroll-behavior: smooth; }
-.extract-preview::-webkit-scrollbar { width: 6px; }
-.extract-preview::-webkit-scrollbar-thumb { background: var(--color-border-secondary); border-radius: 10px; }
-.extract-title { font-size: 11px; font-weight: 700; color: var(--color-text-tertiary); margin-bottom: 12px; letter-spacing: .06em; text-transform: uppercase; display: flex; align-items: center; justify-content: space-between; }
+.paste-hint {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  line-height: 1.5;
+  pointer-events: none;
+}
 
-.extract-card { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); border-radius: var(--border-radius-md); padding: 14px 16px; margin-bottom: 12px; box-shadow: var(--shadow-sm); animation: popIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; transform-origin: center; position: relative; overflow: hidden; }
-.extract-subject { font-size: 11px; font-weight: 700; margin-bottom: 6px; letter-spacing: .04em; text-transform: uppercase; }
-.extract-task-name { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; line-height: 1.4; }
-.extract-row { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 500; color: var(--color-text-secondary); margin-top: 4px; }
-.extract-icon { font-size: 14px; }
-.conf-bar { height: 4px; border-radius: 2px; margin-top: 12px; background: var(--color-border-tertiary); overflow: hidden; }
-.conf-fill { height: 100%; border-radius: 2px; transition: width 1s cubic-bezier(0.16, 1, 0.3, 1); }
-.conf-label { font-size: 11px; font-weight: 600; color: var(--color-text-tertiary); margin-top: 6px; display: flex; justify-content: space-between; }
-.conf-edit { color: var(--color-text-info); cursor: pointer; transition: color 0.2s; }
-.conf-edit:hover { color: var(--color-text-primary); }
+.paste-actions {
+  padding: 0 20px 16px;
+  display: flex;
+  gap: 12px;
+}
 
-.add-btn { margin: 0 20px 20px; padding: 12px; border: none; border-radius: var(--border-radius-md); background: var(--color-text-primary); color: var(--color-background-primary); font-size: 14px; font-weight: 600; cursor: pointer; text-align: center; flex-shrink: 0; box-shadow: 0 4px 12px rgba(0,0,0,0.15); transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
-.add-btn:hover:not(:disabled) { background: var(--color-text-secondary); transform: translateY(-2px); box-shadow: 0 6px 16px rgba(0,0,0,0.2); }
-.add-btn:active:not(:disabled) { transform: translateY(0); box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
-.add-btn:disabled { background: var(--color-border-secondary); cursor: not-allowed; transform: none; box-shadow: none; color: var(--color-text-tertiary); }
+.extract-preview {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 20px 20px;
+  scroll-behavior: smooth;
+}
+
+.extract-preview::-webkit-scrollbar {
+  width: 6px;
+}
+
+.extract-preview::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 10px;
+}
+
+.extract-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  margin-bottom: 12px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.extract-card {
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-md);
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  box-shadow: var(--shadow-sm);
+  animation: popIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  transform-origin: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.extract-subject {
+  font-size: 11px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.extract-task-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.extract-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+}
+
+.extract-icon {
+  font-size: 14px;
+}
+
+.conf-bar {
+  height: 4px;
+  border-radius: 2px;
+  margin-top: 12px;
+  background: var(--color-border-tertiary);
+  overflow: hidden;
+}
+
+.conf-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 1s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.conf-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  margin-top: 6px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.conf-edit {
+  color: var(--color-text-info);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.conf-edit:hover {
+  color: var(--color-text-primary);
+}
+
+.add-btn {
+  margin: 0 20px 20px;
+  padding: 12px;
+  border: none;
+  border-radius: var(--border-radius-md);
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.add-btn:hover:not(:disabled) {
+  background: var(--color-text-secondary);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.add-btn:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.add-btn:disabled {
+  background: var(--color-border-secondary);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  color: var(--color-text-tertiary);
+}
 
 /* Loader */
 .loader-spinner {
   display: inline-block;
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0,0,0,0.1);
+  border: 2px solid rgba(0, 0, 0, 0.1);
   border-radius: 50%;
   border-top-color: var(--color-text-primary);
   animation: spin 0.8s linear infinite;
 }
+
 @media (prefers-color-scheme: dark) {
-  .loader-spinner { border-color: rgba(255,255,255,0.1); border-top-color: #fff; }
+  .loader-spinner {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-top-color: #fff;
+  }
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* Utility classes */
-.hidden { display: none !important; }
+.hidden {
+  display: none !important;
+}
 
 
 
@@ -1298,19 +2730,25 @@ body {
   width: 44px;
   height: 24px;
 }
-.toggle-switch input { 
+
+.toggle-switch input {
   opacity: 0;
   width: 0;
   height: 0;
 }
+
 .toggle-slider {
   position: absolute;
   cursor: pointer;
-  top: 0; left: 0; right: 0; bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   background-color: var(--color-border-primary);
   transition: .3s;
   border-radius: 24px;
 }
+
 .toggle-slider:before {
   position: absolute;
   content: "";
@@ -1322,10 +2760,12 @@ body {
   transition: .3s;
   border-radius: 50%;
 }
-.toggle-switch input:checked + .toggle-slider {
+
+.toggle-switch input:checked+.toggle-slider {
   background-color: var(--color-text-success);
 }
-.toggle-switch input:checked + .toggle-slider:before {
+
+.toggle-switch input:checked+.toggle-slider:before {
   transform: translateX(20px);
 }
 
@@ -1333,26 +2773,38 @@ body {
 body.compact-view {
   padding: 16px 8px;
 }
+
 body.compact-view .app {
   height: 600px;
 }
+
 body.compact-view .task-item {
   padding: 8px 10px;
   margin-bottom: 4px;
 }
+
 body.compact-view .nav-item {
   padding: 8px 10px;
   font-size: 13px;
 }
+
 body.compact-view .topbar {
   padding: 12px 16px;
 }
+
 body.compact-view .cal-section,
 body.compact-view .tasks-section {
   padding: 12px 16px;
 }
+
 /* css/index.css */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 :root {
   --color-background-primary: #ffffff;
@@ -1361,40 +2813,42 @@ body.compact-view .tasks-section {
   --color-text-primary: #1a1a18;
   --color-text-secondary: #6b6b66;
   --color-text-tertiary: #9c9a92;
-  --color-border-tertiary: rgba(0,0,0,0.08); /* softer */
-  --color-border-secondary: rgba(0,0,0,0.15); /* softer */
-  --color-border-primary: rgba(0,0,0,0.30);
-  
+  --color-border-tertiary: rgba(0, 0, 0, 0.08);
+  /* softer */
+  --color-border-secondary: rgba(0, 0, 0, 0.15);
+  /* softer */
+  --color-border-primary: rgba(0, 0, 0, 0.30);
+
   --color-danger-rgb: 163, 45, 45;
   --color-info-rgb: 24, 95, 165;
   --color-success-rgb: 22, 101, 52;
-  
+
   --color-text-danger: #a32d2d;
   --color-background-danger: #fcebeb;
   --color-border-danger: rgba(var(--color-danger-rgb), 0.35);
-  
+
   --color-text-info: #185fa5;
   --color-background-info: #e6f1fb;
   --color-border-info: rgba(var(--color-info-rgb), 0.35);
-  
+
   --color-text-success: #166534;
   --color-background-success: #eaf3de;
   --color-border-success: rgba(var(--color-success-rgb), 0.35);
 
   --color-text-warning: #854f0b;
   --color-background-warning: #faeeda;
-  
+
   --color-text-purple: #3c3489;
   --color-background-purple: #eeedfe;
-  
+
   --border-radius-sm: 6px;
   --border-radius-md: 10px;
   --border-radius-lg: 16px;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  
-  --shadow-sm: 0 2px 8px rgba(0,0,0,0.04);
-  --shadow-md: 0 4px 16px rgba(0,0,0,0.06);
-  --shadow-lg: 0 8px 32px rgba(0,0,0,0.08);
+
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.08);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1405,20 +2859,20 @@ body.compact-view .tasks-section {
     --color-text-primary: #efede5;
     --color-text-secondary: #a3a198;
     --color-text-tertiary: #73726c;
-    --color-border-tertiary: rgba(255,255,255,0.06);
-    --color-border-secondary: rgba(255,255,255,0.12);
-    --color-border-primary: rgba(255,255,255,0.22);
+    --color-border-tertiary: rgba(255, 255, 255, 0.06);
+    --color-border-secondary: rgba(255, 255, 255, 0.12);
+    --color-border-primary: rgba(255, 255, 255, 0.22);
     --color-text-danger: #fc9c9c;
     --color-background-danger: rgba(252, 156, 156, 0.15);
-    --color-border-danger: rgba(252,156,156,0.3);
-    
+    --color-border-danger: rgba(252, 156, 156, 0.3);
+
     --color-text-info: #9ecdfc;
     --color-background-info: rgba(158, 205, 252, 0.15);
-    --color-border-info: rgba(158,205,252,0.3);
-    
+    --color-border-info: rgba(158, 205, 252, 0.3);
+
     --color-text-success: #a0d45a;
     --color-background-success: rgba(160, 212, 90, 0.15);
-    --color-border-success: rgba(160,212,90,0.3);
+    --color-border-success: rgba(160, 212, 90, 0.3);
 
     --color-text-warning: #fab35e;
     --color-background-warning: rgba(250, 179, 94, 0.15);
@@ -1442,14 +2896,43 @@ body {
 }
 
 /* Animations */
-@keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
-@keyframes popIn { 0% { transform: scale(0.95); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
 
-.wrapper { width: 100%; max-width: 1200px; animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes popIn {
+  0% {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.wrapper {
+  width: 100%;
+  max-width: 1200px;
+  animation: fadeIn 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
 
 .label {
-  font-size: 12px; font-weight: 600; color: var(--color-text-tertiary);
-  letter-spacing: .08em; margin-bottom: 12px; text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  letter-spacing: .08em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
 }
 
 .app {
@@ -1466,59 +2949,317 @@ body {
 
 /* Sidebar */
 .sidebar {
-  background: var(--color-background-secondary); border-right: 1px solid var(--color-border-tertiary);
-  padding: 20px 16px; display: flex; flex-direction: column; gap: 4px;
+  background: var(--color-background-secondary);
+  border-right: 1px solid var(--color-border-tertiary);
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
-.sidebar-header { font-size: 11px; font-weight: 700; color: var(--color-text-tertiary); padding: 8px 12px; margin-bottom: 2px; letter-spacing: .06em; text-transform: uppercase; }
-.nav-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--border-radius-md); cursor: pointer; font-size: 14px; font-weight: 500; color: var(--color-text-secondary); transition: all 0.2s ease; position: relative; }
-.nav-item:hover { background: var(--color-background-primary); color: var(--color-text-primary); transform: translateX(2px); }
-.nav-item.active { background: var(--color-background-primary); color: var(--color-text-primary); box-shadow: var(--shadow-sm); }
-.nav-item.active::before { content: ''; position: absolute; left: 0; top: 15%; height: 70%; width: 3px; background: var(--color-text-primary); border-radius: 4px; }
-.nav-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1); }
-.badge { margin-left: auto; font-size: 12px; font-weight: 600; background: var(--color-background-tertiary); color: var(--color-text-secondary); padding: 2px 8px; border-radius: 12px; transition: all 0.2s; }
-.nav-item:hover .badge { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); }
-.sidebar-divider { height: 1px; background: var(--color-border-tertiary); margin: 12px 0; }
-.add-subject { font-size: 13px; font-weight: 500; color: var(--color-text-tertiary); padding: 8px 12px; cursor: pointer; transition: color 0.2s; display: flex; align-items: center; gap: 8px; }
-.add-subject:hover { color: var(--color-text-primary); }
+
+.sidebar-header {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  padding: 8px 12px;
+  margin-bottom: 2px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.nav-item:hover {
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  transform: translateX(2px);
+}
+
+.nav-item.active {
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 15%;
+  height: 70%;
+  width: 3px;
+  background: var(--color-text-primary);
+  border-radius: 4px;
+}
+
+.nav-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.badge {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--color-background-tertiary);
+  color: var(--color-text-secondary);
+  padding: 2px 8px;
+  border-radius: 12px;
+  transition: all 0.2s;
+}
+
+.nav-item:hover .badge {
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-tertiary);
+}
+
+.sidebar-divider {
+  height: 1px;
+  background: var(--color-border-tertiary);
+  margin: 12px 0;
+}
+
+.add-subject {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-subject:hover {
+  color: var(--color-text-primary);
+}
 
 /* Main */
-.main { display: flex; flex-direction: column; overflow: hidden; position: relative; }
-.topbar { display: flex; align-items: center; gap: 12px; padding: 16px 24px; border-bottom: 1px solid var(--color-border-tertiary); flex-shrink: 0; background: rgba(var(--color-background-primary), 0.8); backdrop-filter: blur(10px); z-index: 10; }
-.topbar-title { font-size: 18px; font-weight: 600; color: var(--color-text-primary); flex: 1; }
-.btn { font-family: inherit; font-size: 13px; font-weight: 600; padding: 8px 16px; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); background: var(--color-background-primary); color: var(--color-text-primary); cursor: pointer; transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: var(--shadow-sm); display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
-.btn:hover { background: var(--color-background-secondary); transform: translateY(-1px); box-shadow: var(--shadow-md); }
-.btn:active { transform: translateY(0); box-shadow: 0 0 0; }
-.btn-primary { background: var(--color-text-primary); color: var(--color-background-primary); border-color: transparent; }
-.btn-primary:hover { background: var(--color-text-secondary); }
+.main {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  flex-shrink: 0;
+  background: rgba(var(--color-background-primary), 0.8);
+  backdrop-filter: blur(10px);
+  z-index: 10;
+}
+
+.topbar-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+
+.btn {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: var(--shadow-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.btn:hover {
+  background: var(--color-background-secondary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn:active {
+  transform: translateY(0);
+  box-shadow: 0 0 0;
+}
+
+.btn-primary {
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  border-color: transparent;
+}
+
+.btn-primary:hover {
+  background: var(--color-text-secondary);
+}
 
 /* Calendar */
-.cal-section { padding: 16px 24px; border-bottom: 1px solid var(--color-border-tertiary); flex-shrink: 0; }
-.cal-header { display: flex; align-items: center; margin-bottom: 16px; }
-.cal-title { font-size: 15px; font-weight: 600; flex: 1; color: var(--color-text-primary); }
-.cal-nav { font-size: 18px; color: var(--color-text-secondary); cursor: pointer; padding: 4px 8px; border-radius: 4px; transition: background 0.2s; }
-.cal-nav:hover { background: var(--color-background-secondary); color: var(--color-text-primary); }
-.cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; text-align: center; }
-.cal-day-label { font-size: 11px; color: var(--color-text-tertiary); padding-bottom: 8px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
-.cal-day { font-size: 13px; font-weight: 500; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: var(--border-radius-md); cursor: pointer; color: var(--color-text-secondary); position: relative; transition: all 0.2s; }
-.cal-day:hover { background: var(--color-background-secondary); color: var(--color-text-primary); transform: scale(1.1); z-index: 1; }
-.cal-day.today { background: var(--color-text-primary); color: var(--color-background-primary); box-shadow: var(--shadow-sm); }
-.cal-day-indicators { position: absolute; bottom: 3px; left: 0; right: 0; display: flex; justify-content: center; gap: 3px; }
-.cal-day-indicator { width: 5px; height: 5px; border-radius: 50%; }
-.cal-day.muted { color: var(--color-border-secondary); }
-.cal-legend { display: flex; gap: 16px; margin-top: 16px; font-size: 11px; font-weight: 500; color: var(--color-text-tertiary); justify-content: flex-end; }
-.cal-legend span { display: flex; align-items: center; gap: 6px; }
-.legend-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.cal-section {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  flex-shrink: 0;
+}
+
+.cal-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.cal-title {
+  font-size: 15px;
+  font-weight: 600;
+  flex: 1;
+  color: var(--color-text-primary);
+}
+
+.cal-nav {
+  font-size: 18px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.cal-nav:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+}
+
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  text-align: center;
+}
+
+.cal-day-label {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  padding-bottom: 8px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cal-day {
+  font-size: 13px;
+  font-weight: 500;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  position: relative;
+  transition: all 0.2s;
+}
+
+.cal-day:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+  transform: scale(1.1);
+  z-index: 1;
+}
+
+.cal-day.today {
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.cal-day-indicators {
+  position: absolute;
+  bottom: 3px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 3px;
+}
+
+.cal-day-indicator {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+}
+
+.cal-day.muted {
+  color: var(--color-border-secondary);
+}
+
+.cal-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  justify-content: flex-end;
+}
+
+.cal-legend span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
 
 /* Tasks */
-.tasks-section { flex: 1; overflow-y: auto; padding: 0 24px 24px; scroll-behavior: smooth; }
-.tasks-section::-webkit-scrollbar { width: 6px; }
-.tasks-section::-webkit-scrollbar-thumb { background: var(--color-border-secondary); border-radius: 10px; }
+.tasks-section {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 24px 24px;
+  scroll-behavior: smooth;
+}
+
+.tasks-section::-webkit-scrollbar {
+  width: 6px;
+}
+
+.tasks-section::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 10px;
+}
+
 .tasks-actions-bar {
   margin-top: 18px;
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
 }
+
 .task-action-btn {
   border: 1px solid var(--color-border-success);
   background: var(--color-background-success);
@@ -1530,21 +3271,25 @@ body {
   cursor: pointer;
   transition: all 0.2s ease;
 }
+
 .task-action-btn:hover {
   filter: brightness(0.98);
   transform: translateY(-1px);
 }
+
 .task-action-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
   filter: none;
 }
+
 .task-action-btn-secondary {
   border-color: var(--color-border-info);
   background: var(--color-background-info);
   color: var(--color-text-info);
 }
+
 .tasks-empty-state {
   margin-top: 14px;
   padding: 14px;
@@ -1554,37 +3299,175 @@ body {
   font-size: 13px;
   background: var(--color-background-secondary);
 }
-.tasks-group { margin-top: 24px; animation: fadeIn 0.4s ease forwards; }
-.tasks-group-header { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.tasks-group-header span { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.tasks-group {
+  margin-top: 24px;
+  animation: fadeIn 0.4s ease forwards;
+}
+
+.tasks-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tasks-group-header span {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
 
 .task-item {
-  display: flex; align-items: flex-start; gap: 14px; padding: 12px 14px;
-  border-radius: var(--border-radius-md); cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1px solid transparent; background: var(--color-background-primary);
+  border: 1px solid transparent;
+  background: var(--color-background-primary);
   margin-bottom: 6px;
   border: 1px solid var(--color-border-tertiary);
 }
-.task-item:hover { background: var(--color-background-secondary); transform: translateX(4px); border-color: var(--color-border-secondary); box-shadow: var(--shadow-sm); }
-.task-item.urgent { border-color: var(--color-border-danger); background: linear-gradient(to right, var(--color-background-danger) 0%, var(--color-background-primary) 100%); }
-.task-check { width: 18px; height: 18px; border-radius: 5px; border: 2px solid var(--color-border-secondary); flex-shrink: 0; margin-top: 2px; transition: all 0.2s; position: relative; cursor: pointer; }
-.task-check:hover { border-color: var(--color-text-primary); }
-.task-check.done { background: var(--color-text-success); border-color: var(--color-text-success); }
-.task-check.done::after { content: ''; position: absolute; left: 4px; top: 1px; width: 4px; height: 8px; border: solid white; border-width: 0 2px 2px 0; transform: rotate(45deg); }
-.task-info { flex: 1; min-width: 0; }
-.task-name { font-size: 14px; font-weight: 500; color: var(--color-text-primary); line-height: 1.4; transition: color 0.2s; margin-bottom: 6px; }
-.task-item.done .task-name { text-decoration: line-through; color: var(--color-text-tertiary); }
-.task-meta { font-size: 12px; color: var(--color-text-tertiary); margin-top: 6px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; font-weight: 500; }
-.task-pill { font-size: 11px; padding: 2px 8px; border-radius: 12px; font-weight: 600; display: inline-flex; align-items: center; gap: 4px; border: 1px solid transparent; }
-.pill-red  { background: var(--color-background-danger); color: var(--color-text-danger); border-color: var(--color-border-danger); }
-.pill-blue { background: var(--color-background-info); color: var(--color-text-info); border-color: var(--color-border-info); }
-.pill-green{ background: var(--color-background-success); color: var(--color-text-success); border-color: var(--color-border-success); }
-.pill-amber{ background: var(--color-background-warning); color: var(--color-text-warning); border-color: rgba(133, 79, 11, 0.2); }
-.pill-purple{ background: var(--color-background-purple); color: var(--color-text-purple); border-color: rgba(60, 52, 137, 0.2); }
 
-.conflict-card { font-size: 13px; font-weight: 500; color: var(--color-text-warning); background: var(--color-background-warning); border: 1px solid rgba(133, 79, 11, 0.3); border-radius: var(--border-radius-md); padding: 12px 16px; line-height: 1.5; display: flex; gap: 12px; align-items: flex-start; box-shadow: var(--shadow-sm); }
-.conflict-icon { font-size: 18px; line-height: 1; }
+.task-item:hover {
+  background: var(--color-background-secondary);
+  transform: translateX(4px);
+  border-color: var(--color-border-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.task-item.urgent {
+  border-color: var(--color-border-danger);
+  background: linear-gradient(to right, var(--color-background-danger) 0%, var(--color-background-primary) 100%);
+}
+
+.task-check {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 2px solid var(--color-border-secondary);
+  flex-shrink: 0;
+  margin-top: 2px;
+  transition: all 0.2s;
+  position: relative;
+  cursor: pointer;
+}
+
+.task-check:hover {
+  border-color: var(--color-text-primary);
+}
+
+.task-check.done {
+  background: var(--color-text-success);
+  border-color: var(--color-text-success);
+}
+
+.task-check.done::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 4px;
+  height: 8px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.task-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  line-height: 1.4;
+  transition: color 0.2s;
+  margin-bottom: 6px;
+}
+
+.task-item.done .task-name {
+  text-decoration: line-through;
+  color: var(--color-text-tertiary);
+}
+
+.task-meta {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  margin-top: 6px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-weight: 500;
+}
+
+.task-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+}
+
+.pill-red {
+  background: var(--color-background-danger);
+  color: var(--color-text-danger);
+  border-color: var(--color-border-danger);
+}
+
+.pill-blue {
+  background: var(--color-background-info);
+  color: var(--color-text-info);
+  border-color: var(--color-border-info);
+}
+
+.pill-green {
+  background: var(--color-background-success);
+  color: var(--color-text-success);
+  border-color: var(--color-border-success);
+}
+
+.pill-amber {
+  background: var(--color-background-warning);
+  color: var(--color-text-warning);
+  border-color: rgba(133, 79, 11, 0.2);
+}
+
+.pill-purple {
+  background: var(--color-background-purple);
+  color: var(--color-text-purple);
+  border-color: rgba(60, 52, 137, 0.2);
+}
+
+.conflict-card {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-warning);
+  background: var(--color-background-warning);
+  border: 1px solid rgba(133, 79, 11, 0.3);
+  border-radius: var(--border-radius-md);
+  padding: 12px 16px;
+  line-height: 1.5;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  box-shadow: var(--shadow-sm);
+}
+
+.conflict-icon {
+  font-size: 18px;
+  line-height: 1;
+}
 
 .task-actions {
   display: flex;
@@ -1592,9 +3475,11 @@ body {
   opacity: 0;
   transition: opacity 0.2s;
 }
+
 .task-item:hover .task-actions {
   opacity: 1;
 }
+
 .task-btn {
   padding: 4px 8px;
   border-radius: 4px;
@@ -1606,16 +3491,19 @@ body {
   color: var(--color-text-secondary);
   transition: all 0.2s;
 }
+
 .task-btn:hover {
   background: var(--color-background-secondary);
   color: var(--color-text-primary);
   border-color: var(--color-border-primary);
 }
+
 .task-btn-danger:hover {
   background: var(--color-background-danger);
   color: var(--color-text-danger);
   border-color: var(--color-text-danger);
 }
+
 .task-btn-info:hover {
   background: var(--color-background-info);
   color: var(--color-text-info);
@@ -1623,84 +3511,382 @@ body {
 }
 
 /* Right Panel */
-.panel { border-left: 1px solid var(--color-border-tertiary); display: flex; flex-direction: column; background: var(--color-background-secondary); overflow: hidden; }
-.panel.panel-collapsed { overflow: visible; }
+.panel {
+  border-left: 1px solid var(--color-border-tertiary);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-background-secondary);
+  overflow: hidden;
+}
+
+.panel.panel-collapsed {
+  overflow: visible;
+}
+
 .panel.panel-collapsed .panel-title,
 .panel.panel-collapsed .panel-subtitle,
 .panel.panel-collapsed .paste-zone,
 .panel.panel-collapsed .paste-actions,
 .panel.panel-collapsed .extract-preview,
-.panel.panel-collapsed .add-btn { display: none; }
-.panel-header { padding: 20px 24px 16px; border-bottom: 1px solid var(--color-border-tertiary); background: var(--color-background-primary); flex-shrink: 0; display: flex; align-items: flex-start; gap: 10px; }
-.panel.panel-collapsed .panel-header { padding: 12px; justify-content: center; border-bottom: none; }
-.panel-toggle-btn { flex-shrink: 0; background: none; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--color-text-secondary); transition: all 0.2s; margin-top: 2px; }
-.panel-toggle-btn:hover { background: var(--color-background-secondary); color: var(--color-text-primary); }
-.panel-toggle-icon { transition: transform 0.3s cubic-bezier(0.4,0,0.2,1); }
-.panel-title { font-size: 16px; font-weight: 600; color: var(--color-text-primary); display: flex; align-items: center; gap: 8px; }
-.panel-title svg { opacity: 0.8; }
-.panel-subtitle { font-size: 12px; font-weight: 500; color: var(--color-text-tertiary); margin-top: 4px; }
+.panel.panel-collapsed .add-btn {
+  display: none;
+}
 
-.paste-zone { margin: 20px 20px 12px; border: 2px dashed var(--color-border-secondary); border-radius: var(--border-radius-lg); padding: 24px 20px; text-align: center; cursor: text; transition: all 0.2s; background: var(--color-background-primary); display: flex; flex-direction: column; align-items: center; justify-content: center; position: relative; min-height: 120px; overflow: hidden; }
-.paste-zone:hover { border-color: var(--color-text-info); background: var(--color-background-info); }
-.paste-zone:focus-within { border-color: var(--color-text-primary); border-style: solid; box-shadow: inset 0 0 0 1px var(--color-text-primary); outline: none; }
-.paste-icon { font-size: 24px; margin-bottom: 8px; color: var(--color-text-secondary); transition: color 0.2s; }
-.paste-zone:hover .paste-icon { color: var(--color-text-info); }
+.panel-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--color-border-tertiary);
+  background: var(--color-background-primary);
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.panel.panel-collapsed .panel-header {
+  padding: 12px;
+  justify-content: center;
+  border-bottom: none;
+}
+
+.panel-toggle-btn {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  transition: all 0.2s;
+  margin-top: 2px;
+}
+
+.panel-toggle-btn:hover {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+}
+
+.panel-toggle-icon {
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.panel-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panel-title svg {
+  opacity: 0.8;
+}
+
+.panel-subtitle {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  margin-top: 4px;
+}
+
+.paste-zone {
+  margin: 20px 20px 12px;
+  border: 2px dashed var(--color-border-secondary);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 20px;
+  text-align: center;
+  cursor: text;
+  transition: all 0.2s;
+  background: var(--color-background-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  min-height: 120px;
+  overflow: hidden;
+}
+
+.paste-zone:hover {
+  border-color: var(--color-text-info);
+  background: var(--color-background-info);
+}
+
+.paste-zone:focus-within {
+  border-color: var(--color-text-primary);
+  border-style: solid;
+  box-shadow: inset 0 0 0 1px var(--color-text-primary);
+  outline: none;
+}
+
+.paste-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+  color: var(--color-text-secondary);
+  transition: color 0.2s;
+}
+
+.paste-zone:hover .paste-icon {
+  color: var(--color-text-info);
+}
 
 .paste-input {
-  position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-  width: 100%; height: 100%; opacity: 0; resize: none; border: none; padding: 20px; font-family: inherit; font-size: 13px; z-index: 2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  resize: none;
+  border: none;
+  padding: 20px;
+  font-family: inherit;
+  font-size: 13px;
+  z-index: 2;
 }
-.paste-input:focus, .paste-input:not(:placeholder-shown) { opacity: 1; z-index: 10; background: var(--color-background-primary); color: var(--color-text-primary); outline: none; }
-.paste-label { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 4px; pointer-events: none; }
-.paste-hint { font-size: 12px; color: var(--color-text-tertiary); line-height: 1.5; pointer-events: none; }
 
-.paste-actions { padding: 0 20px 16px; display: flex; gap: 12px; }
+.paste-input:focus,
+.paste-input:not(:placeholder-shown) {
+  opacity: 1;
+  z-index: 10;
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  outline: none;
+}
 
-.extract-preview { flex: 1; overflow-y: auto; padding: 0 20px 20px; scroll-behavior: smooth; }
-.extract-preview::-webkit-scrollbar { width: 6px; }
-.extract-preview::-webkit-scrollbar-thumb { background: var(--color-border-secondary); border-radius: 10px; }
-.extract-title { font-size: 11px; font-weight: 700; color: var(--color-text-tertiary); margin-bottom: 12px; letter-spacing: .06em; text-transform: uppercase; display: flex; align-items: center; justify-content: space-between; }
+.paste-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 4px;
+  pointer-events: none;
+}
 
-.extract-card { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); border-radius: var(--border-radius-md); padding: 14px 16px; margin-bottom: 12px; box-shadow: var(--shadow-sm); animation: popIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; transform-origin: center; position: relative; overflow: hidden; }
-.extract-subject { font-size: 11px; font-weight: 700; margin-bottom: 6px; letter-spacing: .04em; text-transform: uppercase; }
-.extract-task-name { font-size: 14px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; line-height: 1.4; }
-.extract-row { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 500; color: var(--color-text-secondary); margin-top: 4px; }
-.extract-icon { font-size: 14px; }
-.conf-bar { height: 4px; border-radius: 2px; margin-top: 12px; background: var(--color-border-tertiary); overflow: hidden; }
-.conf-fill { height: 100%; border-radius: 2px; transition: width 1s cubic-bezier(0.16, 1, 0.3, 1); }
-.conf-label { font-size: 11px; font-weight: 600; color: var(--color-text-tertiary); margin-top: 6px; display: flex; justify-content: space-between; }
-.conf-edit { color: var(--color-text-info); cursor: pointer; transition: color 0.2s; }
-.conf-edit:hover { color: var(--color-text-primary); }
+.paste-hint {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  line-height: 1.5;
+  pointer-events: none;
+}
 
-.add-btn { margin: 0 20px 20px; padding: 12px; border: none; border-radius: var(--border-radius-md); background: var(--color-text-primary); color: var(--color-background-primary); font-size: 14px; font-weight: 600; cursor: pointer; text-align: center; flex-shrink: 0; box-shadow: 0 4px 12px rgba(0,0,0,0.15); transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
-.add-btn:hover:not(:disabled) { background: var(--color-text-secondary); transform: translateY(-2px); box-shadow: 0 6px 16px rgba(0,0,0,0.2); }
-.add-btn:active:not(:disabled) { transform: translateY(0); box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
-.add-btn:disabled { background: var(--color-border-secondary); cursor: not-allowed; transform: none; box-shadow: none; color: var(--color-text-tertiary); }
+.paste-actions {
+  padding: 0 20px 16px;
+  display: flex;
+  gap: 12px;
+}
+
+.extract-preview {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 20px 20px;
+  scroll-behavior: smooth;
+}
+
+.extract-preview::-webkit-scrollbar {
+  width: 6px;
+}
+
+.extract-preview::-webkit-scrollbar-thumb {
+  background: var(--color-border-secondary);
+  border-radius: 10px;
+}
+
+.extract-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  margin-bottom: 12px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.extract-card {
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-md);
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  box-shadow: var(--shadow-sm);
+  animation: popIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  transform-origin: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.extract-subject {
+  font-size: 11px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.extract-task-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.extract-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+}
+
+.extract-icon {
+  font-size: 14px;
+}
+
+.conf-bar {
+  height: 4px;
+  border-radius: 2px;
+  margin-top: 12px;
+  background: var(--color-border-tertiary);
+  overflow: hidden;
+}
+
+.conf-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 1s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.conf-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  margin-top: 6px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.conf-edit {
+  color: var(--color-text-info);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.conf-edit:hover {
+  color: var(--color-text-primary);
+}
+
+.add-btn {
+  margin: 0 20px 20px;
+  padding: 12px;
+  border: none;
+  border-radius: var(--border-radius-md);
+  background: var(--color-text-primary);
+  color: var(--color-background-primary);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.add-btn:hover:not(:disabled) {
+  background: var(--color-text-secondary);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.add-btn:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.add-btn:disabled {
+  background: var(--color-border-secondary);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  color: var(--color-text-tertiary);
+}
 
 /* Loader */
 .loader-spinner {
   display: inline-block;
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0,0,0,0.1);
+  border: 2px solid rgba(0, 0, 0, 0.1);
   border-radius: 50%;
   border-top-color: var(--color-text-primary);
   animation: spin 0.8s linear infinite;
 }
+
 @media (prefers-color-scheme: dark) {
-  .loader-spinner { border-color: rgba(255,255,255,0.1); border-top-color: #fff; }
+  .loader-spinner {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-top-color: #fff;
+  }
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* Utility classes */
-.hidden { display: none !important; }
+.hidden {
+  display: none !important;
+}
 
 /* Timer duration input */
-.timer-duration-row { display: flex; align-items: center; gap: 10px; }
-.timer-duration-label { font-size: 12px; font-weight: 600; color: var(--color-text-tertiary); text-transform: uppercase; letter-spacing: 0.05em; }
-.timer-duration-input { width: 64px; padding: 6px 10px; border: 1px solid var(--color-border-secondary); border-radius: var(--border-radius-sm); background: var(--color-background-primary); color: var(--color-text-primary); font-size: 14px; font-weight: 600; font-family: inherit; text-align: center; transition: border-color 0.2s; }
-.timer-duration-input:focus { outline: none; border-color: var(--color-text-primary); }
-.timer-duration-input:disabled { opacity: 0.5; cursor: not-allowed; }
+.timer-duration-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.timer-duration-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.timer-duration-input {
+  width: 64px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  text-align: center;
+  transition: border-color 0.2s;
+}
+
+.timer-duration-input:focus {
+  outline: none;
+  border-color: var(--color-text-primary);
+}
+
+.timer-duration-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 /* Focus Mode */
 .focus-section {
@@ -1711,12 +3897,14 @@ body {
   overflow-y: auto;
   gap: 32px;
 }
+
 .focus-dashboard {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 24px;
 }
+
 .timer-container {
   position: relative;
   width: 240px;
@@ -1725,6 +3913,7 @@ body {
   align-items: center;
   justify-content: center;
 }
+
 .timer-svg {
   position: absolute;
   top: 0;
@@ -1733,11 +3922,13 @@ body {
   height: 100%;
   transform: rotate(-90deg);
 }
+
 .timer-path-elapsed {
   fill: none;
   stroke: var(--color-border-tertiary);
   stroke-width: 4;
 }
+
 .timer-path-remaining {
   fill: none;
   stroke: var(--color-text-primary);
@@ -1745,6 +3936,7 @@ body {
   stroke-linecap: round;
   transition: stroke-dashoffset 1s linear;
 }
+
 .timer-text {
   font-size: 48px;
   font-weight: 700;
@@ -1753,15 +3945,19 @@ body {
   letter-spacing: -0.02em;
   z-index: 1;
 }
+
 .timer-controls {
   display: flex;
   gap: 12px;
 }
-.focus-task-container, .focus-task-selector {
+
+.focus-task-container,
+.focus-task-selector {
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
 }
+
 .focus-task-header {
   font-size: 13px;
   font-weight: 600;
@@ -1770,6 +3966,7 @@ body {
   letter-spacing: 0.05em;
   margin-bottom: 12px;
 }
+
 .active-focus-task {
   background: var(--color-background-primary);
   border: 1px solid var(--color-border-primary);
@@ -1781,16 +3978,19 @@ body {
   align-items: center;
   justify-content: center;
 }
+
 .no-task-selected {
   color: var(--color-text-secondary);
   font-size: 14px;
   font-weight: 500;
 }
+
 .focus-task-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
+
 .focus-task-item {
   display: flex;
   align-items: center;
@@ -1802,11 +4002,13 @@ body {
   cursor: pointer;
   transition: all 0.2s;
 }
+
 .focus-task-item:hover {
   background: var(--color-background-secondary);
   border-color: var(--color-text-info);
   transform: translateY(-1px);
 }
+
 .focus-task-item .task-name {
   margin-bottom: 0;
   flex: 1;
@@ -1984,7 +4186,7 @@ body {
 /* Task Addition Model */
 
 
-#new-task-modal{
+#new-task-modal {
 
   position: fixed;
   inset: 0;
@@ -1992,20 +4194,20 @@ body {
   display: none;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.55) !important; 
+  background-color: rgba(0, 0, 0, 0.55) !important;
 }
 
 
 #new-task-modal .modal-card {
   width: 100%;
   max-width: 360px;
-  background-color: #0f172a;                     
+  background-color: #0f172a;
   border-radius: 14px;
   padding: 20px 20px 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6) !important;
-  color: #e5e7eb;                        
+  color: #e5e7eb;
   box-sizing: border-box;
-  border: 1px solid rgba(148, 163, 184, 0.35)  !important;
+  border: 1px solid rgba(148, 163, 184, 0.35) !important;
 }
 
 
@@ -2024,7 +4226,8 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #9ca3af; /* muted */
+  color: #9ca3af;
+  /* muted */
   margin-bottom: 4px;
 }
 
@@ -2037,11 +4240,11 @@ body {
   padding: 7px 8px;
   margin-bottom: 10px;
   border-radius: 6px;
-  border: 1px solid #4b5563;              
-  background-color: #111827 !important;                  
+  border: 1px solid #4b5563;
+  background-color: #111827 !important;
   color: #e5e7eb;
   transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  color-scheme: dark;                      
+  color-scheme: dark;
 }
 
 
@@ -2055,11 +4258,11 @@ body {
   outline: none;
   border-color: #4f46e5;
   box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35);
-  background: #020617;                     
+  background: #020617;
 }
 
 
-#new-task-modal .modal-card > div:last-child {
+#new-task-modal .modal-card>div:last-child {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -2093,6 +4296,7 @@ body {
     opacity: 0;
     transform: translateY(6px) scale(0.97);
   }
+
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
@@ -2147,6 +4351,7 @@ body {
   line-height: 1.5;
   font-size: 13px;
 }
+
 .smart-workload-card.high {
   border-color: rgba(255, 77, 77, 0.5);
   background: rgba(255, 77, 77, 0.08);
@@ -2155,6 +4360,7 @@ body {
 .smart-workload-card.medium {
   border-color: rgba(255, 184, 77, 0.25);
 }
+
 .smart-highlight {
   color: #ffcc66;
   font-weight: 600;

--- a/error.html
+++ b/error.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,7 +15,9 @@
       --border: rgba(0, 0, 0, 0.11);
     }
 
-    * { box-sizing: border-box; }
+    * {
+      box-sizing: border-box;
+    }
 
     body {
       margin: 0;
@@ -63,7 +66,8 @@
       flex-wrap: wrap;
     }
 
-    button, a {
+    button,
+    a {
       border: none;
       border-radius: 10px;
       padding: 10px 14px;
@@ -80,10 +84,11 @@
 
     a {
       color: var(--text);
-      background: #ece9e2;
+      background: var(--card);
     }
   </style>
 </head>
+
 <body>
   <main class="card">
     <h1>Something went wrong</h1>
@@ -95,4 +100,5 @@
     </div>
   </main>
 </body>
+
 </html>


### PR DESCRIPTION
## Changes Made
- Fixed the summary-box card that was appearing in white/light mode
- Updated background from light gradient (#eef2ff, #f8fafc) to dark navy 
  to match the app's existing dark theme

## Issue
The Smart Paste summary card was not following the dark mode theme,
making it visually inconsistent with the rest of the UI.



## Type of Change
- [x] Bug fix (dark mode UI inconsistency)