### PR TITLE
Define input schema for AI-based Smart Study Schedule Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ State Management + UI Sync
 
 ---
 
+## Smart Study Schedule Input Schema
+
+The AI-based Smart Study Schedule Generator should use the standardized input schema defined in:
+
+`backend/models/smartStudyScheduleInput.schema.json`
+
+This schema documents the required payload only. It includes:
+
+- `subjects`: available subjects, with optional existing StudyPlan subject IDs
+- `tasks`: topics, assignments, or study tasks with deadlines, estimated study hours, difficulty, priority, and notes
+- `study_hours`: timezone, schedule date range, weekday availability, and session length preferences
+
+The schema is a data contract for future generator work and does not implement schedule generation.
+
+---
+
 ## 🛠 Tech Stack
 
 | Layer | Technology |
@@ -153,6 +169,9 @@ Open → http://localhost:3000
  
 ```
  StudyPlan
+├──  backend
+│   └──  models
+│       └──  smartStudyScheduleInput.schema.json  # Input schema for future smart schedule generation
 ├──  css
 │   └──  index.css           # Contains all styling rules, variables, and animations
 ├──  js

--- a/backend/models/smartStudyScheduleInput.schema.json
+++ b/backend/models/smartStudyScheduleInput.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studyplan.local/schemas/smart-study-schedule-input.schema.json",
+  "title": "Smart Study Schedule Generator Input",
+  "description": "Standard input payload for a future AI-based Smart Study Schedule Generator. This schema defines the data contract only; it does not implement schedule generation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["subjects", "tasks", "study_hours"],
+  "properties": {
+    "subjects": {
+      "type": "array",
+      "description": "Subjects available for scheduling.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional existing StudyPlan subject id, such as sub_1."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Subject name shown to the student."
+          },
+          "short_code": {
+            "type": "string",
+            "description": "Optional compact label used in the UI."
+          }
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "description": "Topics, assignments, exams, or study tasks that need scheduled study time.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "subject_name", "due_at", "estimated_hours", "difficulty", "priority"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional existing StudyPlan task id."
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Task, topic, chapter, assignment, or exam title."
+          },
+          "subject_id": {
+            "type": "string",
+            "description": "Optional existing StudyPlan subject id."
+          },
+          "subject_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Subject name, matching one item in subjects when possible."
+          },
+          "due_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Deadline in ISO 8601 datetime format."
+          },
+          "estimated_hours": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Estimated total study hours needed for this task."
+          },
+          "difficulty": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Student-perceived difficulty."
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Scheduling priority. High priority tasks should be favored when time is constrained."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional task context, instructions, or extracted notes."
+          }
+        }
+      }
+    },
+    "study_hours": {
+      "type": "object",
+      "description": "Student availability for study sessions.",
+      "additionalProperties": false,
+      "required": ["timezone", "start_date", "end_date", "hours_per_day"],
+      "properties": {
+        "timezone": {
+          "type": "string",
+          "description": "IANA timezone for interpreting dates and study windows, such as Asia/Kolkata."
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date",
+          "description": "First date the schedule may use."
+        },
+        "end_date": {
+          "type": "string",
+          "format": "date",
+          "description": "Last date the schedule may use."
+        },
+        "hours_per_day": {
+          "type": "object",
+          "description": "Available study hours by weekday. Missing days are treated as unavailable.",
+          "additionalProperties": false,
+          "properties": {
+            "monday": { "$ref": "#/$defs/nonNegativeHours" },
+            "tuesday": { "$ref": "#/$defs/nonNegativeHours" },
+            "wednesday": { "$ref": "#/$defs/nonNegativeHours" },
+            "thursday": { "$ref": "#/$defs/nonNegativeHours" },
+            "friday": { "$ref": "#/$defs/nonNegativeHours" },
+            "saturday": { "$ref": "#/$defs/nonNegativeHours" },
+            "sunday": { "$ref": "#/$defs/nonNegativeHours" }
+          }
+        },
+        "preferred_session_minutes": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 240,
+          "default": 60,
+          "description": "Preferred length for one study session."
+        },
+        "max_session_minutes": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 360,
+          "description": "Optional upper limit for one study session."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nonNegativeHours": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 24
+    }
+  }
+}


### PR DESCRIPTION
Fixes #261

## Changes Made

* Added standardized input schema for AI-based smart study schedule generator
* Added fields for subjects, tasks, deadlines, study hours, difficulty, priority, availability, etc.
* Documented schema in README
* Kept changes minimal and scoped only to this issue

## Notes

* No AI generator/business logic was implemented
* No unrelated files were modified
