### PR TITLE
fix: add studyplan.db to .gitignore (closes #320)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Thumbs.db
 # Optional Editor configurations
 .vscode/
 .idea/
+studyplan.db


### PR DESCRIPTION

- Adds studyplan.db to .gitignore so it is never committed again

## Why?
- The SQLite db file should be generated fresh on each local install
- Committing it causes noise in diffs, merge conflicts, and exposes local data

Closes #320