### PR TITLE
fix: resolve task count bug by adjusting date comparisons in summary …

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,9 +6,10 @@ import { analyzeWorkload } from './utils/scheduler.js';
 initGlobalErrorBoundary();
 
 function generateSummary(tasks, subjects) {
-  const now = new Date();
-  const weekEnd = new Date();
-  weekEnd.setDate(now.getDate() + 7);
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const weekEnd = new Date(todayStart);
+  weekEnd.setDate(todayStart.getDate() + 7);
 
   let todayCount = 0;
   let weekCount = 0;
@@ -18,14 +19,15 @@ function generateSummary(tasks, subjects) {
     if (t.archived || t.status === 'Done' || !t.due_at) return;
 
     const d = new Date(t.due_at);
+    const taskDate = new Date(d.getFullYear(), d.getMonth(), d.getDate());
 
     // today
-    if (d.toDateString() === now.toDateString()) {
+    if (+taskDate === +todayStart) {
       todayCount++;
     }
 
     // this week
-    if (d >= now && d <= weekEnd) {
+    if (taskDate >= todayStart && taskDate <= weekEnd) {
       weekCount++;
     }
 
@@ -663,9 +665,11 @@ function renderTasks() {
 }
 
 
-const summaryBox = document.getElementById('summary-box');
-if (summaryBox) {
-  summaryBox.innerHTML = generateSummary(store.tasks, store.subjects);
+function renderSummary() {
+  const summaryBox = document.getElementById('summary-box');
+  if (summaryBox) {
+    summaryBox.innerHTML = generateSummary(store.tasks, store.subjects);
+  }
 }
 
 function renderCalendar() {
@@ -855,6 +859,7 @@ store.subscribe(renderExtraction);
 store.subscribe(renderCalendar);
 store.subscribe(renderFocusTasks);
 store.subscribe(renderSidebarSubjects);
+store.subscribe(renderSummary);
 
 document.addEventListener('DOMContentLoaded', () => {
   if (newSubjectColorsEl) {


### PR DESCRIPTION
…generation

# Related Issue
Closes #384 

# Summary
Fixes the sidebar summary box always showing "Today you have 0 task(s)" and "This week you have 0 task(s)" even when tasks exist.
# Changes Made
-  Replaced one-time inline summary population (ran at module load when store.tasks was empty) with a renderSummary() function subscribed to store changes, so it re-renders whenever tasks/subjects update
-  Normalized date comparisons in generateSummary() to date-only (midnight) instead of comparing raw Date objects with time components — this fixes the weekly count being 0 when a task's UTC timestamp falls earlier in the day than the current time
# Testing
-  Created a task with due_at set to today's date via the UI
-  Verified the sidebar summary box updates to "Today you have 1 task(s)" and "This week you have 1 task(s)" immediately after creation
-  Reloaded the page and confirmed the counts persist correctly on re-render
# Screenshots
<img width="1235" height="843" alt="image" src="https://github.com/user-attachments/assets/9e085bb3-1053-4284-92d5-bb5412ac87da" />

# Checklist
-  Code follows project style
-  Tested locally
-  No unrelated changes included
