### PR TITLE
feat: Add separate privacy, terms, and support pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,9 +212,9 @@
 <footer class="site-footer">
   <p>© 2026 StudyPlan. All rights reserved.</p>
   <div class="footer-links">
-    <a href="/support-page/index.html#privacy">Privacy</a>
-    <a href="/support-page/index.html#terms">Terms</a>
-    <a href="/support-page/index.html#support">Support</a>
+    <a href="/support-page/privacy.html">Privacy</a>
+    <a href="/support-page/terms.html">Terms</a>
+    <a href="/support-page/support.html">Support</a>
   </div>
 </footer>
 

--- a/support-page/privacy.html
+++ b/support-page/privacy.html
@@ -3,10 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Support | StudyPlan</title>
+  <title>Privacy Policy | StudyPlan</title>
+
   <link rel="stylesheet" href="/support-page/support.css">
+
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
+
 <body>
 
 <header class="site-header">
@@ -17,57 +20,40 @@
 
   <nav class="header-nav">
     <a href="/" class="nav-btn">Dashboard</a>
-    <a href="#" class="nav-btn">Tasks</a>
-    <a href="#" class="nav-btn">Calendar</a>
-    <a href="#" class="nav-btn">Settings</a>
   </nav>
 </header>
 
 <main class="support-wrapper">
 
-  <section id="support" class="card">
-    <h2>Support</h2>
-    <p>If you need help using StudyPlan, contact our support team.</p>
-    <ul>
-      <li>Email: support@studyplan.com</li>
-      <li>Response Time: Within 24 hours</li>
-      <li>Availability: Monday to Friday</li>
-    </ul>
-  </section>
-
-  <section id="privacy" class="card">
+  <section class="card">
     <h2>Privacy Policy</h2>
+
     <p>
       StudyPlan values your privacy. We securely store your tasks and academic planning data.
       We do not sell your personal information to third parties.
     </p>
+
     <p>
       Data submitted through AI extraction is processed only for task extraction purposes.
     </p>
-  </section>
 
-  <section id="terms" class="card">
-    <h2>Terms & Conditions</h2>
-    <p>
-      By using StudyPlan, you agree to use the service responsibly.
-      Users are responsible for verifying deadlines extracted by AI before submission.
-    </p>
-    <p>
-      StudyPlan is not liable for missed deadlines caused by incorrect user input or AI inference errors.
-    </p>
   </section>
 
 </main>
 
 <footer class="site-footer">
+
   <p>© 2026 StudyPlan. All rights reserved.</p>
+
   <div class="footer-links">
-    <a href="#privacy">Privacy</a>
-    <a href="#terms">Terms</a>
-    <a href="#support">Support</a>
+    <a href="/support-page/privacy.html">Privacy</a>
+    <a href="/support-page/terms.html">Terms</a>
+    <a href="/support-page/support.html">Support</a>
   </div>
+
 </footer>
 
 <script src="/support-page/support.js"></script>
+
 </body>
 </html>

--- a/support-page/support.html
+++ b/support-page/support.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Support | StudyPlan</title>
+  <link rel="stylesheet" href="/support-page/support.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-left">
+    <img src="/logo.png" alt="Logo" class="logo">
+    <h1 class="site-title">StudyPlan</h1>
+  </div>
+
+  <nav class="header-nav">
+    <a href="/" class="nav-btn">Dashboard</a>
+  </nav>
+</header>
+
+<main class="support-wrapper">
+
+  <section id="support" class="card">
+    <h2>Support</h2>
+    <p>If you need help using StudyPlan, contact our support team.</p>
+    <ul>
+      <li>Email: support@studyplan.com</li>
+      <li>Response Time: Within 24 hours</li>
+      <li>Availability: Monday to Friday</li>
+    </ul>
+  </section>
+
+  <!-- <section id="privacy" class="card">
+    <h2>Privacy Policy</h2>
+    <p>
+      StudyPlan values your privacy. We securely store your tasks and academic planning data.
+      We do not sell your personal information to third parties.
+    </p>
+    <p>
+      Data submitted through AI extraction is processed only for task extraction purposes.
+    </p>
+  </section>
+
+  <section id="terms" class="card">
+    <h2>Terms & Conditions</h2>
+    <p>
+      By using StudyPlan, you agree to use the service responsibly.
+      Users are responsible for verifying deadlines extracted by AI before submission.
+    </p>
+    <p>
+      StudyPlan is not liable for missed deadlines caused by incorrect user input or AI inference errors.
+    </p>
+  </section> -->
+
+</main>
+
+<footer class="site-footer">
+  <p>© 2026 StudyPlan. All rights reserved.</p>
+  <div class="footer-links">
+    <a href="/support-page/privacy.html">Privacy</a>
+    <a href="/support-page/terms.html">Terms</a>
+    <a href="/support-page/support.html">Support</a>
+  </div>
+</footer>
+
+<script src="/support-page/support.js"></script>
+</body>
+</html>

--- a/support-page/terms.html
+++ b/support-page/terms.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Terms & Conditions | StudyPlan</title>
+
+  <link rel="stylesheet" href="/support-page/support.css">
+
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+
+<body>
+
+<header class="site-header">
+
+  <div class="header-left">
+    <img src="/logo.png" alt="Logo" class="logo">
+    <h1 class="site-title">StudyPlan</h1>
+  </div>
+
+  <nav class="header-nav">
+    <a href="/" class="nav-btn">Dashboard</a>
+  </nav>
+
+</header>
+
+<main class="support-wrapper">
+
+  <section class="card">
+
+    <h2>Terms & Conditions</h2>
+
+    <p>
+      By using StudyPlan, you agree to use the service responsibly.
+      Users are responsible for verifying deadlines extracted by AI before submission.
+    </p>
+
+    <p>
+      StudyPlan is not liable for missed deadlines caused by incorrect user input or AI inference errors.
+    </p>
+
+  </section>
+
+</main>
+
+<footer class="site-footer">
+
+  <p>© 2026 StudyPlan. All rights reserved.</p>
+
+  <div class="footer-links">
+    <a href="/support-page/privacy.html">Privacy</a>
+    <a href="/support-page/terms.html">Terms</a>
+    <a href="/support-page/support.html">Support</a>
+  </div>
+
+</footer>
+
+<script src="/support-page/support.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
# Related Issue
Closes #193

# Summary
Created separate pages for Privacy Policy, Terms , and Support to improve footer navigation and page structure.

# Changes Made
- Renamed `support-page/index.html` to `support.html`
- Added `privacy.html`
- Added `terms.html`
- Updated footer links to navigate to dedicated pages
- Removed section-based navigation using hash routes
- Maintained existing styling using shared CSS

# Testing
- Tested all pages locally using `node server.js`
- Verified footer navigation links
- Confirmed pages render correctly without broken routes

# Screenshots
Add screenshots of:
- Privacy page
<img width="1919" height="972" alt="Screenshot 2026-05-19 142745" src="https://github.com/user-attachments/assets/8dc47a20-6452-4d82-b572-704665fbcee5" />

- Terms page
<img width="1919" height="968" alt="Screenshot 2026-05-19 142755" src="https://github.com/user-attachments/assets/38cb4ca2-084a-4db6-a65c-b7a78b2a2d68" />

- Support page
<img width="1919" height="965" alt="Screenshot 2026-05-19 142807" src="https://github.com/user-attachments/assets/ef455981-ad51-43ce-a673-ad0d71e32168" />



# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
