### PR TITLE
feat: implemented dynamic show/hide clear button logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1045,6 +1045,11 @@ addItemsBtn.addEventListener('click', () => {
 });
 });
 
+// Ensures the button is hidden on initial page load if the textarea is empty
+if (pasteInput.value.trim() === "") {
+    clearBtn.style.display = 'none';
+}
+
 extractBtn.addEventListener('click', async () => {
   const text = pasteInput.value;
   if (!text.trim()) return;
@@ -1060,9 +1065,21 @@ extractBtn.addEventListener('click', async () => {
   store.setExtracted(items);
 });
 
+// Wipes the text, clears the store, hides the button, and refocuses the cursor
 clearBtn.addEventListener('click', () => {
-  pasteInput.value = '';
-  store.clearExtracted();
+    pasteInput.value = '';
+    store.clearExtracted();
+    clearBtn.style.display = 'none'; // Hides the clear button instantly
+    pasteInput.focus();              // Puts the typing cursor back in the box
+});
+
+// Listens to typing/pasting to show or hide the button dynamically
+pasteInput.addEventListener('input', () => {
+    if (pasteInput.value.trim().length > 0) {
+        clearBtn.style.display = 'block'; 
+    } else {
+        clearBtn.style.display = 'none';
+    }
 });
 
 addItemsBtn.addEventListener('click', () => {


### PR DESCRIPTION
# Related Issue
Closes #253 
# Summary
This contribution enhances the UX of the "Smart Paste" text panel by making the "Clear" button dynamic. Instead of remaining statically visible or unlinked, the button now hides automatically when the text area is empty on page load, reveals itself instantly as soon as a user types or pastes text, and smoothly resets the input state upon being clicked.

# Changes Made
- Added a conditional page-load execution block in `js/app.js` to ensure the clear button initiates as hidden (`display: none`) if the textarea contains no text.
- Enhanced the existing `clearBtn` click event listener to explicitly hide the button instantly and return input `.focus()` to the text area upon resetting.
- Implemented a dynamic `input` event listener on `pasteInput` to actively track value lengths, triggering `clearBtn.style.display` toggles between `'block'` and `'none'`.

# Testing
- Tested locally across browsers by checking the initial UI state (button correctly hidden on load).
- Verified the input handler by pasting multi-line unformatted text blocks (button instantly becomes visible).
- Confirmed the reset workflow by clicking the button (text is wiped cleanly, the storage store is reset, the button hides, and the flashing cursor focus remains inside the empty input box).


# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)