### PR TITLE
fix: update favicon path to public/favicon.ico

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>StudyPlan</title>
   <link rel="stylesheet" href="/css/index.css">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="public/favicon.ico" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
# Summary
Updated the favicon path in index.html to correctly point to 
public/favicon.ico where the file actually exists.

# Changes Made
- Changed favicon href from `/favicon.ico` to `public/favicon.ico`

# Testing
Opened index.html in browser and confirmed favicon now displays 
correctly in the browser tab.

# Screenshots
<img width="609" height="129" alt="Screenshot 2026-05-19 234024" src="https://github.com/user-attachments/assets/4d8dca04-0e70-4321-8645-e7c7b59093d2" />

<img width="499" height="113" alt="Screenshot 2026-05-19 234327" src="https://github.com/user-attachments/assets/2d6695c5-a56a-40d9-b99f-3ab3476f0526" />

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)