### PR TITLE
fix: resolve column corruption in CSV downloads.

### DIFF
--- a/backend/controllers/csvDownload.controller.js
+++ b/backend/controllers/csvDownload.controller.js
@@ -10,6 +10,16 @@ const { db } = require("../../database.js");
  */
 
 
+function escapeCSVField(val) {
+    if (val === null || val === undefined) return '';
+    const str = String(val);
+    // If the field contains quotes, commas, or newlines, escape quotes and wrap in quotes
+    if (/[",\r\n]/.test(str)) {
+        return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+}
+
 async function downloadData(req, res) {
     try {
         const query = `
@@ -24,21 +34,21 @@ async function downloadData(req, res) {
             });
         });
 
-        const rows = [
-            ["Task ID", "Subject", "Title", "Due At", "Status", "Priority", "Confidence Score", "Notes"],
-            ...data.map(task => [
-                task.id,
-                task.subject_name,
-                task.title,
-                task.due_at,
-                task.status,
-                task.priority,
-                task.confidence_score,
-                `"${(task.notes || '').replace(/"/g, '""')}"`
-            ])
-        ];
+        const headers = ["Task ID", "Subject", "Title", "Due At", "Status", "Priority", "Confidence Score", "Notes"];
+        const rows = data.map(task => [
+            task.id,
+            task.subject_name,
+            task.title,
+            task.due_at,
+            task.status,
+            task.priority,
+            task.confidence_score,
+            task.notes
+        ]);
 
-        const csvString = rows.map(row => row.join(',')).join('\n');
+        const csvString = [headers, ...rows]
+            .map(row => row.map(escapeCSVField).join(','))
+            .join('\n');
 
         res.setHeader('Content-Type', 'text/csv');
         res.setHeader('Content-Disposition', 'attachment; filename="study_data.csv"');


### PR DESCRIPTION
# Related Issue
None (Self-discovered formatting bug)

# Summary
This PR fixes a bug in the CSV download export where columns would shift and corrupt the spreadsheet if tasks contained commas (`,`), double quotes (`"`), or newlines (`\n`) in their text fields. We now use RFC-4180 compliant escaping on all fields before joining them.

# Changes Made
- Added an `escapeCSVField` helper function to handle quote-escaping and wrap fields with commas or quotes in double-quotes.
- Updated the row mapper in `backend/controllers/csvDownload.controller.js` to apply `escapeCSVField` to all exported columns.

# Testing
- Created a task with commas and quotes in the title (`CS Homework, Part "1"`) and notes (`Read pages 1, 2, and 3`) and exported to CSV.
- Verified that the fields are properly escaped (`"CS Homework, Part ""1"""` and `"Read pages 1, 2, and 3"`) and alignment is preserved.

# Screenshots
None (Backend change only)

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)
