### PR TITLE
feat: display priority badges on task cards.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -513,6 +513,16 @@ function renderTasks() {
              <button class="task-btn task-btn-info restore-task-btn" data-id="${t.id}" title="Restore">Restore</button>
              <button class="task-btn task-btn-danger delete-task-btn" data-id="${t.id}" title="Permanent Delete">Delete</button>`;
 
+        let priorityClass = 'pill-blue';
+        let priorityLabel = '🔵 Low';
+        if (t.priority === 'high') {
+          priorityClass = 'pill-red';
+          priorityLabel = '🔴 High';
+        } else if (t.priority === 'medium') {
+          priorityClass = 'pill-amber';
+          priorityLabel = '🟡 Medium';
+        }
+
         html += `
           <div class="task-item ${isUrgent ? 'urgent' : ''} ${isDone ? 'done' : ''}" data-id="${t.id}">
             <div class="task-check ${isDone ? 'done' : ''}"></div>
@@ -521,6 +531,7 @@ function renderTasks() {
               <div class="task-meta">
                 <span class="task-pill ${isDone ? 'pill-green' : (isUrgent ? 'pill-red' : 'pill-amber')}">${isDone ? 'Done' : 'Due ' + formatDate(t.due_at)}</span>
                 <span class="task-pill ${pillClass}">${sub.short_code}</span>
+                <span class="task-pill ${priorityClass}">${priorityLabel}</span>
               </div>
             </div>
             <div class="task-actions">


### PR DESCRIPTION
# Summary
Displays the task priority level (High, Medium, Low) as a color-coded badge pill on every task card in the dashboard.

# Changes Made
- Added priority detection logic in `renderTasks()` in `js/app.js`
- Maps `high` → 🔴 red pill, `medium` → 🟡 amber pill, `low` → 🔵 blue pill
- Uses existing `.pill-red`, `.pill-amber`, `.pill-blue` CSS classes (no CSS changes needed)

# Testing
- Verified tasks render with the correct priority badge based on their stored priority value

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)
