### PR TITLE
fix: prevent selecting past deadlines in Add Task modal (fixes #474)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -984,6 +984,10 @@ newTaskBtn.addEventListener('click', () => {
     .map(s => `<option value="${s.id}">${s.name}</option>`)
     .join('');
 
+  // FIX #474: Prevent selecting past dates — set min to current date/time
+  const nowMin = new Date();
+  nowMin.setSeconds(0, 0);
+  newTaskDate.min = nowMin.toISOString().substring(0, 16);
 
   if (selectedDate) {
     const d = new Date(selectedDate);


### PR DESCRIPTION
## 🐛 Bug Fix — Prevent Past Deadline Selection in Add Task Modal

Closes #474

---

## Problem

When opening the **"Add Task"** modal, the `datetime-local` input had no `min` attribute set. This allowed users to freely select any past date/time as a task deadline, which makes no logical sense for a study planner and leads to tasks immediately appearing as overdue.

## Root Cause

```js
// BEFORE — no min restriction, any date allowed
if (selectedDate) {
  const d = new Date(selectedDate);
  d.setHours(18, 0, 0, 0);
  newTaskDate.value = d.toISOString().substring(0, 16);
} else {
  newTaskDate.value = '';
}
```

## Fix

Set the `min` attribute on `newTaskDate` every time the modal opens, dynamically refreshed to the **current moment**:

```js
// AFTER — past dates are greyed out and blocked by the browser
const nowMin = new Date();
nowMin.setSeconds(0, 0);
newTaskDate.min = nowMin.toISOString().substring(0, 16);
```

## Changes

| File | Change |
|---|---|
| `js/app.js` | +3 lines inside `newTaskBtn` click handler |

No other files were modified. Zero risk of regression.

## Testing

- [x] Open "Add Task" modal → past dates greyed out and unselectable
- [x] Today's current time and future dates work normally
- [x] Pre-filled date from calendar click still works correctly
- [x] No change to existing task editing, dashboard, or any other feature

---

> **GSSoC '26 Contributor:** lucifers-0666