### PR TITLE
fix: prevent multiple save clicks and duplicate subject names

### DIFF
--- a/server.js
+++ b/server.js
@@ -258,16 +258,32 @@ app.post('/api/subjects', (req, res) => {
   if (!ALLOWED_SUBJECT_COLORS.has(color)) {
     color = 'var(--color-text-info)';
   }
-  const shortCode = name.replace(/[^a-zA-Z0-9]/g, '').toUpperCase().slice(0, 4) || 'SUB';
-  const id = `sub_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-  db.run(
-    'INSERT INTO subjects (id, name, short_code, color) VALUES (?, ?, ?, ?)',
-    [id, name, shortCode, color],
-    function (err) {
-      if (err) return res.status(500).json({ error: err.message });
-      res.status(201).json({ id, name, short_code: shortCode, color });
+  db.get(
+    'SELECT * FROM subjects WHERE LOWER(name) = LOWER(?)',
+    [name],
+    (err, row) => {
+      if (err) {
+        return res.status(500).json({ error: err.message });
+      }
+
+      if (row) {
+        return res.status(400).json({
+          error: 'Subject already exists',
+        });
+      }
+
+      const shortCode = name.replace(/[^a-zA-Z0-9]/g, '').toUpperCase().slice(0, 4) || 'SUB';
+      const id = `sub_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+      db.run(
+        'INSERT INTO subjects (id, name, short_code, color) VALUES (?, ?, ?, ?)',
+        [id, name, shortCode, color],
+        function (err) {
+          if (err) return res.status(500).json({ error: err.message });
+          res.status(201).json({ id, name, short_code: shortCode, color });
+        }
+      );
     }
-  );
+  )
 });
 
 // ================= TASKS =================


### PR DESCRIPTION
# Related Issue
Closes #142 

# Summary
Added validation to prevent creating duplicate subjects in the subjects API.
Prevent multiple save clicks which create multiple subjects.

# Changes Made
- Added duplicate subject name validation before inserting into the database.
- Implemented case-insensitive subject name checking.
- Returned an error response when a duplicate subject already exists.

# Testing
Tested locally by creating new subjects and verifying that duplicate subject names are rejected correctly.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)