### PR TITLE
feat: Add a break button on Focus page with complete functionality #492

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
           <div class="timer-controls">
             <button id="timer-start-btn" class="btn btn-primary">Start Focus</button>
             <button id="timer-pause-btn" class="btn hidden">Pause</button>
+            <button id="timer-continue-btn" class="btn hidden">Continue</button>
             <button id="timer-reset-btn" class="btn">Reset</button>
           </div>
           

--- a/js/app.js
+++ b/js/app.js
@@ -150,6 +150,8 @@ const timerPathRemaining = document.getElementById('timer-path-remaining');
 const timerStartBtn = document.getElementById('timer-start-btn');
 const timerPauseBtn = document.getElementById('timer-pause-btn');
 const timerResetBtn = document.getElementById('timer-reset-btn');
+const timerContinueBtn =
+  document.getElementById('timer-continue-btn');
 
 // Task elements
 const focusTaskList = document.getElementById('focus-task-list');
@@ -193,12 +195,16 @@ function setCircleDasharray() {
 
 function startTimer() {
   if (timerInterval) return;
-  TIME_LIMIT = getTimerDuration();
-  if (timePassed === 0) timeLeft = TIME_LIMIT;
-  timerDurationInput.disabled = true;
+
+  timerContinueBtn.classList.add('hidden');
   timerStartBtn.classList.add('hidden');
   timerPauseBtn.classList.remove('hidden');
-  
+
+  TIME_LIMIT = getTimerDuration();
+  if (timePassed === 0) timeLeft = TIME_LIMIT;
+
+  timerDurationInput.disabled = true;
+
   timerInterval = setInterval(() => {
     timePassed += 1;
     timeLeft = TIME_LIMIT - timePassed;
@@ -217,8 +223,10 @@ function startTimer() {
 function pauseTimer() {
   clearInterval(timerInterval);
   timerInterval = null;
+
   timerPauseBtn.classList.add('hidden');
-  timerStartBtn.classList.remove('hidden');
+  timerStartBtn.classList.add('hidden');
+  timerContinueBtn.classList.remove('hidden');
 }
 
 function resetTimer() {
@@ -231,7 +239,8 @@ function resetTimer() {
   timerText.innerHTML = formatTimeLeft(timeLeft);
   timerPathRemaining.setAttribute("stroke-dasharray", "283 283");
   timerPauseBtn.classList.add('hidden');
-  timerStartBtn.classList.remove('hidden');
+timerContinueBtn.classList.add('hidden');
+timerStartBtn.classList.remove('hidden');
 }
 
 timerDurationInput.addEventListener('change', () => {
@@ -263,6 +272,8 @@ if (panelToggleBtn) {
 if(timerStartBtn) timerStartBtn.addEventListener('click', startTimer);
 if(timerPauseBtn) timerPauseBtn.addEventListener('click', pauseTimer);
 if(timerResetBtn) timerResetBtn.addEventListener('click', resetTimer);
+if (timerContinueBtn)
+  timerContinueBtn.addEventListener('click', startTimer);
 
 function renderFocusTasks() {
   if(!focusTaskList || !activeFocusTask) return;


### PR DESCRIPTION
# Related Issue

Closes #492

# Summary

Implemented break and continue functionality for the Focus Mode timer.

# Changes Made

* Added a **Continue** button to resume paused focus sessions.
* Improved **Pause/Break** functionality in Focus Mode.
* Updated timer controls to properly switch between **Start**, **Pause**, and **Continue** states.
* Ensured timer resumes from paused duration instead of restarting.
* Reset functionality restores the timer to the initial state.

# Testing

Tested locally:

* ✅ Start timer works correctly
* ✅ Pause/Break stops timer
* ✅ Continue resumes timer from paused duration
* ✅ Reset restores initial timer state
* ✅ Timer completion flow still works

# Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
