### PR TITLE
fix: prevent auth modal from appearing for authenticated users (#531)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <!-- Auth Modal -->
-<div id="auth-modal" style="display:flex; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:9999; align-items:center; justify-content:center;">
+<div id="auth-modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:9999; align-items:center; justify-content:center;">
   <div style="background:white; border-radius:16px; padding:32px; width:360px; box-shadow:0 20px 60px rgba(0,0,0,0.3);">
     
     <h2 id="auth-title" style="margin:0 0 8px; font-size:22px; font-weight:700;">Welcome back</h2>
@@ -319,9 +319,9 @@
     }
   });
 
-  // Check if already logged in
-  if (localStorage.getItem('studyplan_user')) {
-    document.getElementById('auth-modal').style.display = 'none';
+  // Show login modal if not logged in
+  if (!localStorage.getItem('studyplan_user')) {
+    document.getElementById('auth-modal').style.display = 'flex';
   }
 
   // Logout Button Functionality

--- a/server.js
+++ b/server.js
@@ -456,7 +456,7 @@ app.post('/api/auth/signup', (req, res) => {
     return res.status(400).json({ error: 'User already exists' });
   }
   users[email] = { email, password };
-  res.json({ success: true, message: 'Account created successfully' });
+  res.json({ success: true, message: 'Account created successfully', email });
 });
 
 app.post('/api/auth/login', (req, res) => {


### PR DESCRIPTION
### 📚 Description
Fixes a bug where the "Create Account" modal rendered on top of the dashboard for already authenticated users. Because this modal has no close button, it rendered the dashboard inaccessible during active sessions or page reloads.

This PR sets the modal to be hidden by default (`display:none`) and dynamically shows it only when the user is confirmed to be unauthenticated, completely resolving the flashing/flicker and lockout issues.

### Changes Implemented
- **Frontend CSS/HTML:** Modified `#auth-modal` in `index.html` to be hidden by default.
- **Frontend Logic:** Updated the inline authentication script to set `display = 'flex'` only if the user does *not* exist in `localStorage`.
- **Backend API Consistency:** Updated `/api/auth/signup` in `server.js` to return the `email` of the registered user, matching the `/api/auth/login` endpoint structure and ensuring proper state storage in `localStorage` upon registration.

### Verification & Testing
- Simulated navigation directly to the dashboard when already logged in: Lands directly on the active session with **no modal shown**.
- Simulated accessing the dashboard while not logged in: **Modal appears instantly** as expected to request login/registration.
- Completed full sign-up and login cycles to confirm seamless user state persistence.

### 🏆 GSSoC '26 Contributor
- **Role:** GSSoC '26 Participant
- **Username:** @Nandhini-kancha
- **Closes #531**