### PR TITLE
feat: add color picker for existing subject customisation

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -122,6 +122,36 @@ body {
 .nav-item.active { background: var(--color-background-primary); color: var(--color-text-primary); box-shadow: var(--shadow-sm); }
 .nav-item.active::before { content: ''; position: absolute; left: 0; top: 15%; height: 70%; width: 3px; background: var(--color-text-primary); border-radius: 4px; }
 .nav-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1); }
+.subject-color-picker {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  padding: 0;
+  background: transparent;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+  transition: transform 0.15s ease;
+}
+.subject-color-picker:hover {
+  transform: scale(1.2);
+}
+.subject-color-picker::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+.subject-color-picker::-webkit-color-swatch {
+  border: none;
+  border-radius: 50%;
+}
+.subject-color-picker::-moz-color-swatch {
+  border: none;
+  border-radius: 50%;
+}
 .badge { margin-left: auto; font-size: 12px; font-weight: 600; background: var(--color-background-tertiary); color: var(--color-text-secondary); padding: 2px 8px; border-radius: 12px; transition: all 0.2s; }
 .nav-item:hover .badge { background: var(--color-background-primary); border: 1px solid var(--color-border-tertiary); }
 .sidebar-divider { height: 1px; background: var(--color-border-tertiary); margin: 12px 0; }

--- a/js/app.js
+++ b/js/app.js
@@ -5,6 +5,28 @@ import { analyzeWorkload } from './utils/scheduler.js';
 
 initGlobalErrorBoundary();
 
+function rgbToHex(rgb) {
+  const match = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
+  if (!match) return '#000000';
+  const r = parseInt(match[1]).toString(16).padStart(2, '0');
+  const g = parseInt(match[2]).toString(16).padStart(2, '0');
+  const b = parseInt(match[3]).toString(16).padStart(2, '0');
+  return `#${r}${g}${b}`;
+}
+
+function resolveColorToHex(colorStr) {
+  if (!colorStr) return '#000000';
+  if (colorStr.startsWith('#')) return colorStr;
+  
+  const temp = document.createElement('div');
+  temp.style.color = colorStr;
+  document.body.appendChild(temp);
+  const resolved = window.getComputedStyle(temp).color;
+  document.body.removeChild(temp);
+  
+  return rgbToHex(resolved);
+}
+
 function generateSummary(tasks, subjects) {
   const now = new Date();
   const weekEnd = new Date();
@@ -130,10 +152,33 @@ function renderSidebarSubjects() {
   listEl.innerHTML = subjects.map(s => {
     const n = countBySubject[s.id] ?? 0;
     const safeColor = s.color ? escapeHtml(s.color) : 'var(--color-text-info)';
+    const hexColor = resolveColorToHex(safeColor);
     return `<div class="nav-item subject-sidebar-item" data-subject-id="${escapeHtml(s.id)}">
-      <span class="nav-dot" style="background:${safeColor}"></span>${escapeHtml(s.name)}<span class="badge">${n}</span>
+      <input type="color" class="subject-color-picker" value="${hexColor}" data-subject-id="${escapeHtml(s.id)}" style="background:${safeColor}">
+      ${escapeHtml(s.name)}
+      <span class="badge">${n}</span>
     </div>`;
   }).join('');
+
+  listEl.querySelectorAll('.subject-color-picker').forEach(picker => {
+    picker.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+
+    picker.addEventListener('input', (e) => {
+      e.stopPropagation();
+      const subjectId = e.target.dataset.subjectId;
+      const newColor = e.target.value;
+      store.updateSubjectColorLocal(subjectId, newColor);
+    });
+
+    picker.addEventListener('change', (e) => {
+      e.stopPropagation();
+      const subjectId = e.target.dataset.subjectId;
+      const newColor = e.target.value;
+      store.updateSubjectColor(subjectId, newColor);
+    });
+  });
 }
 
 const newTaskModal = document.getElementById('new-task-modal');
@@ -286,18 +331,15 @@ function renderFocusTasks() {
     focusTaskList.innerHTML = '<div class="tasks-empty-state">No tasks due soon to focus on.</div>';
   } else {
     focusTaskList.innerHTML = dueSoon.map(t => {
-      const sub = subjects.find(s => s.id === t.subject_id) || subjects[0] || { short_code: 'Gen' };
-      let pillClass = '';
-      if(sub.short_code === 'CS') pillClass = 'pill-blue';
-      else if(sub.short_code === 'Maths') pillClass = 'pill-green';
-      else if(sub.short_code === 'English') pillClass = 'pill-purple';
-      else pillClass = 'pill-amber';
+      const sub = subjects.find(s => s.id === t.subject_id) || subjects[0] || { short_code: 'Gen', color: 'var(--color-text-info)' };
+      const safeColor = sub.color ? escapeHtml(sub.color) : 'var(--color-text-info)';
+      const pillStyle = `background: color-mix(in srgb, ${safeColor} 12%, transparent); color: ${safeColor}; border: 1px solid color-mix(in srgb, ${safeColor} 30%, transparent);`;
       
       return `
         <div class="focus-task-item" data-id="${t.id}">
           <div class="task-name">${t.title}</div>
           <div class="task-meta">
-            <span class="task-pill ${pillClass}">${sub.short_code}</span>
+            <span class="task-pill" style="${pillStyle}">${escapeHtml(sub.short_code)}</span>
           </div>
         </div>
       `;
@@ -314,13 +356,16 @@ function renderFocusTasks() {
   if (activeFocusTaskId) {
     const activeT = store.tasks.find(t => t.id === activeFocusTaskId);
     if (activeT) {
-      const sub = subjects.find(s => s.id === activeT.subject_id) || subjects[0] || { name: 'General' };
+      const sub = subjects.find(s => s.id === activeT.subject_id) || subjects[0] || { name: 'General', color: 'var(--color-text-info)' };
+      const safeColor = sub.color ? escapeHtml(sub.color) : 'var(--color-text-info)';
+      const pillStyle = `background: color-mix(in srgb, ${safeColor} 12%, transparent); color: ${safeColor}; border: 1px solid color-mix(in srgb, ${safeColor} 30%, transparent);`;
+      
       activeFocusTask.innerHTML = `
         <div class="task-info" style="width: 100%">
           <div class="task-name" style="font-size: 16px;">${activeT.title}</div>
           <div class="task-meta">
             <span class="task-pill pill-amber">Due ${formatDate(activeT.due_at)}</span>
-            <span class="task-pill">${sub.name}</span>
+            <span class="task-pill" style="${pillStyle}">${escapeHtml(sub.name)}</span>
           </div>
           <div style="margin-top: 12px; display: flex; gap: 8px;">
             <button class="btn btn-primary complete-focus-task-btn" data-id="${activeT.id}">Mark Done</button>
@@ -459,15 +504,12 @@ function renderTasks() {
     
       
     items.forEach(t => {
-      const sub = subjects.find(s => s.id === t.subject_id) || subjects[0];
+      const sub = subjects.find(s => s.id === t.subject_id) || subjects[0] || { short_code: 'Gen', color: 'var(--color-text-info)' };
       const isUrgent = t.priority === 'high' && title === '⚠ Due soon';
       const isDone = t.status === 'Done';
       
-      let pillClass = '';
-      if(sub.short_code === 'CS') pillClass = 'pill-blue';
-      else if(sub.short_code === 'Maths') pillClass = 'pill-green';
-      else if(sub.short_code === 'English') pillClass = 'pill-purple';
-      else pillClass = 'pill-amber';
+      const safeColor = sub.color ? escapeHtml(sub.color) : 'var(--color-text-info)';
+      const pillStyle = `background: color-mix(in srgb, ${safeColor} 12%, transparent); color: ${safeColor}; border: 1px solid color-mix(in srgb, ${safeColor} 30%, transparent);`;
       
       if (t._isEditing) {
         let subjectOptions = subjects.map(s => 
@@ -520,7 +562,7 @@ function renderTasks() {
               <div class="task-name">${t.title}</div>
               <div class="task-meta">
                 <span class="task-pill ${isDone ? 'pill-green' : (isUrgent ? 'pill-red' : 'pill-amber')}">${isDone ? 'Done' : 'Due ' + formatDate(t.due_at)}</span>
-                <span class="task-pill ${pillClass}">${sub.short_code}</span>
+                <span class="task-pill" style="${pillStyle}">${escapeHtml(sub.short_code)}</span>
               </div>
             </div>
             <div class="task-actions">

--- a/js/store.js
+++ b/js/store.js
@@ -62,6 +62,41 @@ export const store = {
     }
   },
 
+  updateSubjectColorLocal(subjectId, newColor) {
+    const sub = this.subjects.find(s => String(s.id) === String(subjectId));
+    if (sub) {
+      sub.color = newColor;
+      this.notify();
+    }
+  },
+
+  async updateSubjectColor(subjectId, newColor) {
+    const subIndex = this.subjects.findIndex(s => String(s.id) === String(subjectId));
+    if (subIndex === -1) return;
+
+    const originalColor = this.subjects[subIndex].color;
+
+    // Optimistic update
+    this.subjects[subIndex] = { ...this.subjects[subIndex], color: newColor };
+    this.notify();
+
+    try {
+      const res = await fetch(`/api/subjects/${subjectId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ color: newColor })
+      });
+      if (!res.ok) {
+        throw new Error('Failed to update subject color');
+      }
+    } catch (e) {
+      console.error('Failed to update subject color', e);
+      // Revert on failure
+      this.subjects[subIndex].color = originalColor;
+      this.notify();
+    }
+  },
+
   // ================= UPDATED FUNCTION =================
   async addTasks(newTasks) {
     try {

--- a/server.js
+++ b/server.js
@@ -249,13 +249,17 @@ const ALLOWED_SUBJECT_COLORS = new Set([
   'var(--color-text-secondary)',
 ]);
 
+function isValidColor(color) {
+  return ALLOWED_SUBJECT_COLORS.has(color) || /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(color);
+}
+
 app.post('/api/subjects', (req, res) => {
   const name = String(req.body?.name || '').trim();
   let color = String(req.body?.color || '').trim() || 'var(--color-text-info)';
   if (!name) {
     return res.status(400).json({ error: 'Subject name is required' });
   }
-  if (!ALLOWED_SUBJECT_COLORS.has(color)) {
+  if (!isValidColor(color)) {
     color = 'var(--color-text-info)';
   }
   const shortCode = name.replace(/[^a-zA-Z0-9]/g, '').toUpperCase().slice(0, 4) || 'SUB';
@@ -266,6 +270,24 @@ app.post('/api/subjects', (req, res) => {
     function (err) {
       if (err) return res.status(500).json({ error: err.message });
       res.status(201).json({ id, name, short_code: shortCode, color });
+    }
+  );
+});
+
+app.put('/api/subjects/:id', (req, res) => {
+  const { color } = req.body;
+  if (!color) {
+    return res.status(400).json({ error: 'Color is required' });
+  }
+  if (!isValidColor(color)) {
+    return res.status(400).json({ error: 'Invalid color format' });
+  }
+  db.run(
+    'UPDATE subjects SET color = ? WHERE id = ?',
+    [color, req.params.id],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ success: true, changes: this.changes });
     }
   );
 });


### PR DESCRIPTION
Closes #517

## Changes
- Added circular color picker (native HTML input type="color") to each 
  subject in the sidebar
- Colors persist in SQLite via new PUT /api/subjects/:id API endpoint
- Real-time color sync across sidebar, calendar indicators, and task pills
- Task subject badges now use dynamic CSS color-mix() based on subject color
- Supports both default CSS variables and custom hex colors

## Files Changed
- server.js — Added isValidColor() + PUT /api/subjects/:id
- js/store.js — Added updateSubjectColorLocal() + updateSubjectColor()
- css/index.css — Circular color picker styles + browser pseudo-elements
- js/app.js — Color resolver helpers + picker DOM + dynamic pill styling