### PR TITLE
auth: Replace plaintext password storage with bcrypt and SQLite persistence

### DIFF
--- a/database.js
+++ b/database.js
@@ -30,6 +30,14 @@ function initDb() {
       FOREIGN KEY (subject_id) REFERENCES subjects(id)
     )`);
 
+    // Users Table
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+
     // Pre-populate some subjects if empty
     db.get('SELECT COUNT(*) as count FROM subjects', (err, row) => {
       if (row && row.count === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google/genai": "^1.49.0",
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -184,6 +185,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -1310,19 +1320,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "@google/genai": "^1.49.0",
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const { db, initDb } = require('./database');
 const { GoogleGenAI } = require('@google/genai');
 const path = require('path');
+const bcrypt = require('bcryptjs');
 const csvDownloadRouter = require('./backend/routers/csvDownload.router.js');
 
 const app = express();
@@ -445,30 +446,78 @@ Text: "${text}"
   return res.json(tasks);
 });
 // ================= AUTH =================
-const users = {}; // Simple in-memory user store
+function normalizeEmail(email) {
+  return String(email || '').trim().toLowerCase();
+}
 
-app.post('/api/auth/signup', (req, res) => {
+function generateUserId() {
+  return `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+app.post('/api/auth/signup', async (req, res) => {
   const { email, password } = req.body;
-  if (!email || !password) {
+  const normalizedEmail = normalizeEmail(email);
+  const plainPassword = String(password || '');
+
+  if (!normalizedEmail || !plainPassword) {
     return res.status(400).json({ error: 'Email and password required' });
   }
-  if (users[email]) {
-    return res.status(400).json({ error: 'User already exists' });
+
+  try {
+    const passwordHash = await bcrypt.hash(plainPassword, 12);
+    const id = generateUserId();
+
+    db.run(
+      'INSERT INTO users (id, email, password_hash) VALUES (?, ?, ?)',
+      [id, normalizedEmail, passwordHash],
+      function (err) {
+        if (err) {
+          if (err.code === 'SQLITE_CONSTRAINT') {
+            return res.status(400).json({ error: 'User already exists' });
+          }
+          return res.status(500).json({ error: err.message });
+        }
+
+        return res.status(201).json({
+          success: true,
+          message: 'Account created successfully',
+          email: normalizedEmail
+        });
+      }
+    );
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to create account' });
   }
-  users[email] = { email, password };
-  res.json({ success: true, message: 'Account created successfully' });
 });
 
 app.post('/api/auth/login', (req, res) => {
   const { email, password } = req.body;
-  if (!email || !password) {
+  const normalizedEmail = normalizeEmail(email);
+  const plainPassword = String(password || '');
+
+  if (!normalizedEmail || !plainPassword) {
     return res.status(400).json({ error: 'Email and password required' });
   }
-  const user = users[email];
-  if (!user || user.password !== password) {
-    return res.status(401).json({ error: 'Invalid email or password' });
-  }
-  res.json({ success: true, email: user.email });
+
+  db.get(
+    'SELECT email, password_hash FROM users WHERE email = ?',
+    [normalizedEmail],
+    async (err, user) => {
+      if (err) return res.status(500).json({ error: err.message });
+      if (!user) return res.status(401).json({ error: 'Invalid email or password' });
+
+      try {
+        const isValidPassword = await bcrypt.compare(plainPassword, user.password_hash);
+        if (!isValidPassword) {
+          return res.status(401).json({ error: 'Invalid email or password' });
+        }
+
+        return res.json({ success: true, email: user.email });
+      } catch (compareErr) {
+        return res.status(500).json({ error: 'Failed to verify credentials' });
+      }
+    }
+  );
 });
 
 // Intentional test route for verifying server error page behavior.


### PR DESCRIPTION
Closes #503

This PR fixes the auth vulnerability where passwords were stored in plaintext in an in-memory object and were lost on server restart.

What changed:
- Added a persistent `users` table in SQLite (`id`, `email`, `password_hash`, `created_at`).
- Added `bcryptjs` dependency.
- Replaced in-memory auth logic in `server.js`:
  - `POST /api/auth/signup` now hashes passwords with bcrypt (cost factor 12) and stores users in DB.
  - `POST /api/auth/login` now fetches by email and verifies with `bcrypt.compare`.
- Normalized email input using `trim().toLowerCase()`.
- Added duplicate-user handling using SQLite unique constraint checks.

Local verification done:
- Signup works for a new user.
- Login works with correct password.
- Login fails with wrong password (401).
- Duplicate signup returns 400.
- Login still works after server restart (persistence confirmed).
- Password is stored as bcrypt hash, not plaintext.