### PR TITLE
Fix timezone mismatch in deadline comparison

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,10 +29,30 @@ const ai = process.env.GEMINI_API_KEY
 // ============================================================
 
 function nlpAddDays(date, n) {
-  const d = new Date(date); d.setDate(d.getDate() + n); return d;
+  const d = new Date(date);
+
+  return new Date(
+    Date.UTC(
+      d.getUTCFullYear(),
+      d.getUTCMonth(),
+      d.getUTCDate() + n
+    )
+  );
 }
 function nlpStartOf(date) {
-  const d = new Date(date); d.setHours(23, 59, 0, 0); return d;
+  const d = new Date(date);
+
+  return new Date(
+    Date.UTC(
+      d.getUTCFullYear(),
+      d.getUTCMonth(),
+      d.getUTCDate(),
+      23,
+      59,
+      0,
+      0
+    )
+  );
 }
 function nlpWithTime(dateStr, t) {
   const d = new Date(dateStr);


### PR DESCRIPTION
# Related Issue
Closes #487

# Summary
This PR fixes timezone-related inconsistencies in task deadline evaluation by replacing local timezone-based date operations with UTC-normalized logic.

# Changes Made
- Updated `nlpAddDays()` to use UTC-safe date calculations
- Updated `nlpStartOf()` to normalize comparisons using UTC timestamps
- Prevented inconsistent overdue/scheduling behavior across different client timezones
- Removed dependency on local machine timezone for deadline evaluation

# Testing
- Tested locally using different timezone settings
- Verified that deadline calculations remain consistent after timezone changes
- Confirmed no runtime errors after modifying date utility functions

# Screenshots
N/A

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)