### PR TITLE
Fix plaintext password storage with bcrypt and SQLite persistence (#503)

### DIFF
--- a/database.js
+++ b/database.js
@@ -30,6 +30,14 @@ function initDb() {
       FOREIGN KEY (subject_id) REFERENCES subjects(id)
     )`);
 
+    // Users Table
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+
     // Pre-populate some subjects if empty
     db.get('SELECT COUNT(*) as count FROM subjects', (err, row) => {
       if (row && row.count === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google/genai": "^1.49.0",
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -184,6 +185,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "@google/genai": "^1.49.0",
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const { db, initDb } = require('./database');
+const bcrypt = require('bcryptjs');
 const { GoogleGenAI } = require('@google/genai');
 const path = require('path');
 const csvDownloadRouter = require('./backend/routers/csvDownload.router.js');
@@ -445,30 +446,68 @@ Text: "${text}"
   return res.json(tasks);
 });
 // ================= AUTH =================
-const users = {}; // Simple in-memory user store
+const BCRYPT_SALT_ROUNDS = 12;
 
-app.post('/api/auth/signup', (req, res) => {
-  const { email, password } = req.body;
+function normalizeEmail(email) {
+  return String(email || '').trim().toLowerCase();
+}
+
+app.post('/api/auth/signup', async (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  const password = req.body?.password;
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' });
   }
-  if (users[email]) {
-    return res.status(400).json({ error: 'User already exists' });
+
+  try {
+    const passwordHash = await bcrypt.hash(String(password), BCRYPT_SALT_ROUNDS);
+    const id = `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+
+    db.run(
+      'INSERT INTO users (id, email, password_hash) VALUES (?, ?, ?)',
+      [id, email, passwordHash],
+      function (err) {
+        if (err) {
+          if (err.code === 'SQLITE_CONSTRAINT' || err.message.includes('UNIQUE')) {
+            return res.status(400).json({ error: 'User already exists' });
+          }
+          return res.status(500).json({ error: err.message });
+        }
+
+        return res.status(201).json({ success: true, message: 'Account created successfully' });
+      }
+    );
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
   }
-  users[email] = { email, password };
-  res.json({ success: true, message: 'Account created successfully' });
 });
 
 app.post('/api/auth/login', (req, res) => {
-  const { email, password } = req.body;
+  const email = normalizeEmail(req.body?.email);
+  const password = req.body?.password;
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' });
   }
-  const user = users[email];
-  if (!user || user.password !== password) {
-    return res.status(401).json({ error: 'Invalid email or password' });
-  }
-  res.json({ success: true, email: user.email });
+
+  db.get(
+    'SELECT email, password_hash FROM users WHERE email = ?',
+    [email],
+    async (err, user) => {
+      if (err) return res.status(500).json({ error: err.message });
+      if (!user) return res.status(401).json({ error: 'Invalid email or password' });
+
+      try {
+        const validPassword = await bcrypt.compare(String(password), user.password_hash);
+        if (!validPassword) {
+          return res.status(401).json({ error: 'Invalid email or password' });
+        }
+
+        return res.json({ success: true, email: user.email });
+      } catch (compareErr) {
+        return res.status(500).json({ error: compareErr.message });
+      }
+    }
+  );
 });
 
 // Intentional test route for verifying server error page behavior.


### PR DESCRIPTION
# Related Issue
Closes #503

# Summary
Fixed insecure authentication storage by replacing plaintext, in-memory password handling with bcrypt-hashed passwords persisted in SQLite.

# Changes Made
- Added a persistent `users` table in `database.js`
- Added `bcryptjs` as a dependency
- Replaced in-memory `const users = {}` storage
- Hashes passwords before saving during signup
- Uses `bcrypt.compare()` during login
- Normalizes email addresses before storage and lookup
- Handles duplicate user signup with a proper error response

# Testing
Tested locally by:
- Creating a new account through `/api/auth/signup`
- Verifying the password is stored as a bcrypt hash, not plaintext
- Logging in with the correct password
- Confirming wrong password login is rejected
- Confirming duplicate signup is rejected
- Restarting the server and verifying login still works
- Running syntax checks with `node --check server.js` and `node --check database.js`

# Screenshots
N/A - backend/auth storage change only.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (not applicable)