### PR TITLE
Fix new task modal closing on outside click causing data lossfix: prevent new task modal from closing on outside click

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1003,11 +1003,11 @@ newTaskCancel.addEventListener('click', () => {
   newTaskModal.style.display = 'none';
 });
 
-newTaskModal.addEventListener('click', (e) => {
-  if (e.target === newTaskModal) {
-    newTaskModal.style.display = 'none';
-  }
-});
+//newTaskModal.addEventListener('click', (e) => {
+//  if (e.target === newTaskModal) {
+ //   newTaskModal.style.display = 'none';
+ // }
+//});
 
 newTaskSave.addEventListener('click', async () => {
   const title = newTaskTitle.value.trim();


### PR DESCRIPTION
# Related Issue

Closes #580

# Summary

Fixes an issue where the New Task modal closed when users clicked outside the modal while interacting with the date picker, causing unsaved task data to be lost.

# Changes Made

* Removed outside-click modal closing behavior for the New Task modal.
* Preserved entered task information while selecting a date.
* Ensured the modal closes only through explicit actions such as Save or Cancel.

# Testing

* Ran the application locally using `npm start`.
* Opened the Add New Task modal.
* Entered task details and opened the date picker.
* Clicked outside the modal area.
* Verified that the modal remained open and entered data was preserved.
* Verified that Save and Cancel actions continue to work correctly.
* Verified that clicking outside the modal no longer closes the form.

# Screenshots

Not applicable. No visual UI changes were made.

# Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
* [ ] Documentation updated (if applicable)
