### PR TITLE
fix: Fix race condition and duplicate insertion handling in POST /api/tasks

### DIFF
--- a/database.js
+++ b/database.js
@@ -29,6 +29,8 @@ function initDb() {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (subject_id) REFERENCES subjects(id)
     )`);
+    db.run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_unique_date_title_subject
+      ON tasks (LOWER(title), subject_id, DATE(due_at))`);
 
     // Pre-populate some subjects if empty
     db.get('SELECT COUNT(*) as count FROM subjects', (err, row) => {

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const { db, initDb } = require('./database');
 const { GoogleGenAI } = require('@google/genai');
+const { randomUUID } = require('crypto');
 const path = require('path');
 const csvDownloadRouter = require('./backend/routers/csvDownload.router.js');
 
@@ -279,7 +280,7 @@ app.get('/api/tasks', (req, res) => {
 });
 
 // ================= ADD TASKS =================
-app.post('/api/tasks', (req, res) => {
+app.post('/api/tasks', async (req, res) => {
   try {
     const tasks = Array.isArray(req.body) ? req.body : [req.body];
 
@@ -291,77 +292,50 @@ app.post('/api/tasks', (req, res) => {
     let duplicates = [];
     let errors = [];
 
-    const stmt = db.prepare(`INSERT INTO tasks 
-      (id, subject_id, title, due_at, status, priority, confidence_score, notes) 
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
-
-    let pending = tasks.length;
-
-    tasks.forEach(t => {
-      if (!t.title || !t.due_at || !t.subject_id) {
-        errors.push({ task: t, error: "Missing title, subject or due date" });
-        pending--;
-        if (pending === 0) {
-          stmt.finalize(() => res.status(400).json({ success: false, inserted, duplicates, errors, message: "All tasks invalid" }));
+    const taskPromises = tasks.map(t => {
+      return new Promise((resolve) => {
+        if (!t.title || !t.due_at || !t.subject_id) {
+          errors.push({ task: t, error: "Missing title, subject or due date" });
+          return resolve();
         }
-        return;
-      }
 
-      db.get(
-        `SELECT * FROM tasks WHERE LOWER(title) = LOWER(?) AND subject_id = ? AND DATE(due_at) = DATE(?)`,
-        [t.title, t.subject_id, t.due_at],
-        (err, existing) => {
-          if (err) {
-            errors.push({ task: t, error: err.message });
-          } else if (existing) {
-            duplicates.push({
-              title: t.title,
-              due_at: t.due_at,
-              subject_id: t.subject_id
-            });
-          } else {
-            const id = 'task_' + Date.now() + Math.random().toString(36).substr(2, 5);
-            stmt.run(
-              id,
-              t.subject_id,
-              t.title,
-              t.due_at,
-              t.status || 'Not Started',
-              t.priority || 'medium',
-              t.confidence_score || 100,
-              t.notes || '',
-              function (insertErr) {
-                if (insertErr) {
-                  errors.push({ task: t, error: insertErr.message });
-                } else {
-                  inserted++;
-                }
+        const id = 'task_' + randomUUID();
+        db.run(
+          `INSERT INTO tasks 
+            (id, subject_id, title, due_at, status, priority, confidence_score, notes) 
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [id, t.subject_id, t.title, t.due_at, t.status || 'Not Started', t.priority || 'medium', t.confidence_score || 100, t.notes || ''],
+          function (insertErr) {
+            if (insertErr) {
+              if (insertErr.code?.includes('SQLITE_CONSTRAINT')) {
+                duplicates.push({ title: t.title, due_at: t.due_at, subject_id: t.subject_id });
+              } else {
+                errors.push({ task: t, error: insertErr.message });
               }
-            );
+            } else {
+              inserted++;
+            }
+            resolve();
           }
+        );
+      });
+    });
 
-          pending--;
-          if (pending === 0) {
-            stmt.finalize((finalErr) => {
-              if (finalErr) return res.status(500).json({ success: false, message: "Database error", error: finalErr.message });
-              return res.json({
-                success: true,
-                inserted,
-                duplicates,
-                errors,
-                message:
-                  errors.length > 0 && duplicates.length > 0
-                    ? "Some tasks failed and some duplicates were skipped"
-                    : errors.length > 0
-                      ? "Some tasks failed to add"
-                      : duplicates.length > 0
-                        ? "Duplicate tasks were skipped"
-                        : "All tasks added successfully"
-              });
-            });
-          }
-        }
-      );
+    await Promise.all(taskPromises);
+
+    return res.json({
+      success: true,
+      inserted,
+      duplicates,
+      errors,
+      message:
+        errors.length > 0 && duplicates.length > 0
+          ? "Some tasks failed and some duplicates were skipped"
+          : errors.length > 0
+            ? "Some tasks failed to add"
+            : duplicates.length > 0
+              ? "Duplicate tasks were skipped"
+              : "All tasks added successfully"
     });
 
   } catch (e) {


### PR DESCRIPTION
# Related Issue

Fixes #602

# Summary

Improved concurrent task insertion handling in `POST /api/tasks`.

# Changes Made

* Replaced manual async tracking with `Promise.all`
* Removed unsafe duplicate pre-check queries
* Added database-driven duplicate handling using SQLite constraints
* Improved unique ID generation using `crypto.randomUUID()`
* Improved SQLite constraint error handling

# Testing

* Tested normal task creation flow
* Tested duplicate task insertions
* Verified duplicate tasks are skipped safely without crashing the server
* Added screenshot proof of duplicate handling behavior
