### PR TITLE
Feat : Handle date parser edge cases and dense calendar days

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2519,3 +2519,30 @@ body {
   color: #ffcc66;
   font-weight: 600;
 }
+
+/* Keep busy calendar days readable without allowing markers to resize cells. */
+.cal-day {
+  overflow: hidden;
+}
+
+.cal-day-indicators {
+  align-items: center;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.cal-day-indicator {
+  flex: 0 0 5px;
+}
+
+.cal-day-overflow {
+  color: var(--color-text-tertiary);
+  flex: 0 0 auto;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.cal-day.today .cal-day-overflow {
+  color: var(--color-background-primary);
+}

--- a/js/app.js
+++ b/js/app.js
@@ -824,12 +824,16 @@ function renderCalendar() {
 
     let indicatorHtml = '';
     if (dayTasks.length > 0) {
-      indicatorHtml = `<div class="cal-day-indicators">`;
-      dayTasks.forEach((t, idx) => {
-         if (idx > 2) return;
+      const visibleCount = dayTasks.length > 3 ? 2 : dayTasks.length;
+      const hiddenCount = dayTasks.length - visibleCount;
+      indicatorHtml = `<div class="cal-day-indicators" aria-label="${dayTasks.length} pending task${dayTasks.length === 1 ? '' : 's'}">`;
+      dayTasks.slice(0, visibleCount).forEach((t) => {
          const sub = store.subjects.find(s => s.id === t.subject_id) || store.subjects[0];
          indicatorHtml += `<div class="cal-day-indicator" style="background:${sub ? sub.color : 'var(--color-text-danger)'}"></div>`;
       });
+      if (hiddenCount > 0) {
+        indicatorHtml += `<span class="cal-day-overflow">+${hiddenCount}</span>`;
+      }
       indicatorHtml += `</div>`;
     }
 

--- a/js/utils/nlpDateExtractor.js
+++ b/js/utils/nlpDateExtractor.js
@@ -141,31 +141,32 @@ const MONTHS = {
 };
 
 function matchAbsoluteDate(lower, now) {
-  // "april 25", "25 april", "25th april", "april 25th"
+  // "april 25", "25 april", "25th april 2026", "april 25th, 2026"
   const monthNames = Object.keys(MONTHS).join('|');
   const ordinal = `(\\d{1,2})(?:st|nd|rd|th)?`;
+  const optionalYear = `(?:,?\\s+(\\d{4}|\\d{2}))?`;
 
   let m;
 
-  m = lower.match(new RegExp(`\\b(${monthNames})\\s+${ordinal}\\b`));
+  m = lower.match(new RegExp(`\\b(${monthNames})\\s+${ordinal}${optionalYear}\\b`));
   if (m) {
     const month = MONTHS[m[1]];
     const day = parseInt(m[2]);
-    return toISO(startOf(resolveYear(now, month, day)));
+    return toISO(startOf(resolveYear(now, month, day, parseYear(m[3]))));
   }
 
-  m = lower.match(new RegExp(`\\b${ordinal}\\s+(${monthNames})\\b`));
+  m = lower.match(new RegExp(`\\b${ordinal}\\s+(${monthNames})${optionalYear}\\b`));
   if (m) {
     const day = parseInt(m[1]);
     const month = MONTHS[m[2]];
-    return toISO(startOf(resolveYear(now, month, day)));
+    return toISO(startOf(resolveYear(now, month, day, parseYear(m[3]))));
   }
 
   m = lower.match(/\b(\d{1,2})[\/\-\.](\d{1,2})(?:[\/\-\.](\d{2,4}))?\b/);
   if (m) {
     const day = parseInt(m[1]);
     const month = parseInt(m[2]) - 1;
-    const year = m[3] ? (m[3].length === 2 ? 2000 + parseInt(m[3]) : parseInt(m[3])) : null;
+    const year = parseYear(m[3]);
     return toISO(startOf(resolveYear(now, month, day, year)));
   }
 
@@ -175,8 +176,14 @@ function matchAbsoluteDate(lower, now) {
 function resolveYear(now, month, day, explicitYear = null) {
   if (explicitYear) return new Date(explicitYear, month, day);
   const candidate = new Date(now.getFullYear(), month, day);
-  if (candidate < now) candidate.setFullYear(candidate.getFullYear() + 1);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  if (candidate < today) candidate.setFullYear(candidate.getFullYear() + 1);
   return candidate;
+}
+
+function parseYear(rawYear) {
+  if (!rawYear) return null;
+  return rawYear.length === 2 ? 2000 + parseInt(rawYear) : parseInt(rawYear);
 }
 
 function matchEndOfPeriod(lower, now) {

--- a/server.js
+++ b/server.js
@@ -70,8 +70,14 @@ const NLP_MONTHS = {
 function nlpResolveYear(now, month, day, explicitYear = null) {
   if (explicitYear) return new Date(explicitYear, month, day);
   const c = new Date(now.getFullYear(), month, day);
-  if (c < now) c.setFullYear(c.getFullYear() + 1);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  if (c < today) c.setFullYear(c.getFullYear() + 1);
   return c;
+}
+
+function nlpParseYear(rawYear) {
+  if (!rawYear) return null;
+  return rawYear.length === 2 ? 2000 + parseInt(rawYear) : parseInt(rawYear);
 }
 
 function nlpExtractDate(text, now = new Date()) {
@@ -105,15 +111,16 @@ function nlpExtractDate(text, now = new Date()) {
 
   const monthNames = Object.keys(NLP_MONTHS).join('|');
   const ord = `(\\d{1,2})(?:st|nd|rd|th)?`;
-  m = lower.match(new RegExp(`\\b(${monthNames})\\s+${ord}\\b`));
-  if (m) return nlpWithTime(nlpStartOf(nlpResolveYear(now, NLP_MONTHS[m[1]], parseInt(m[2]))).toISOString(), time);
-  m = lower.match(new RegExp(`\\b${ord}\\s+(${monthNames})\\b`));
-  if (m) return nlpWithTime(nlpStartOf(nlpResolveYear(now, NLP_MONTHS[m[2]], parseInt(m[1]))).toISOString(), time);
+  const optionalYear = `(?:,?\\s+(\\d{4}|\\d{2}))?`;
+  m = lower.match(new RegExp(`\\b(${monthNames})\\s+${ord}${optionalYear}\\b`));
+  if (m) return nlpWithTime(nlpStartOf(nlpResolveYear(now, NLP_MONTHS[m[1]], parseInt(m[2]), nlpParseYear(m[3]))).toISOString(), time);
+  m = lower.match(new RegExp(`\\b${ord}\\s+(${monthNames})${optionalYear}\\b`));
+  if (m) return nlpWithTime(nlpStartOf(nlpResolveYear(now, NLP_MONTHS[m[2]], parseInt(m[1]), nlpParseYear(m[3]))).toISOString(), time);
 
   m = lower.match(/\b(\d{1,2})[\/\-\.](\d{1,2})(?:[\/\-\.](\d{2,4}))?\b/);
   if (m) {
     const day = parseInt(m[1]), month = parseInt(m[2]) - 1;
-    const yr = m[3] ? (m[3].length === 2 ? 2000 + parseInt(m[3]) : parseInt(m[3])) : null;
+    const yr = nlpParseYear(m[3]);
     return nlpWithTime(nlpStartOf(nlpResolveYear(now, month, day, yr)).toISOString(), time);
   }
 


### PR DESCRIPTION
## Summary
- Fixed ambiguous named dates entered on the current day so they remain in the current year instead of incorrectly rolling to the next year.
- Added support for explicit years in named-month inputs such as `October 12, 2025` and `12 October 2027`.
- Improved calendar rendering for overlapping deadlines by showing bounded task markers with a compact `+N` overflow count, preventing dense days from disrupting the layout.

## Testing
- Ran `npm.cmd test`.
- Ran syntax checks for the updated server and frontend JavaScript files.
- Ran `git diff --check`.
- Verified the `/api/extract` flow with an explicit-year date and a same-day date rollover case.

Closes #596