### PR TITLE
feat: Add drag and drop file upload to smart paste.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2156,7 +2156,18 @@ body {
 .smart-workload-card.medium {
   border-color: rgba(255, 184, 77, 0.25);
 }
+
 .smart-highlight {
   color: #ffcc66;
   font-weight: 600;
+}
+
+.paste-zone {
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.paste-zone--dragover {
+  border-color: #4f46e5 !important;
+  background-color: rgba(79, 70, 229, 0.05) !important;
+  box-shadow: inset 0 0 8px rgba(79, 70, 229, 0.1);
 }

--- a/index.html
+++ b/index.html
@@ -181,11 +181,13 @@
         </div>
       </div>
 
-      <div class="paste-zone">
+      <div class="paste-zone" id = "drop-zone">
         <div class="paste-icon">⌘ V</div>
-        <div class="paste-label">Paste text here</div>
-        <div class="paste-hint">e.g. "Your OS assignment is due this Friday by 11pm…"</div>
+        <div class="paste-label">Paste text or drop a file here</div>
+        <div class="paste-hint">Supports .txt, .md, or .json files (e.g. "Your OS assignment is due this Friday by 11pm…)"</div>
         <textarea id="paste-input" class="paste-input" placeholder="Paste your syllabus or notes..."></textarea>
+        <div class="file-upload-wrapper" style="margin-top: 10px; font-size: 13px; text-align: center;">
+          </div>
       </div>
 
       <div class="paste-actions">

--- a/js/app.js
+++ b/js/app.js
@@ -1076,3 +1076,77 @@ addItemsBtn.addEventListener('click', () => {
 downloadBtn.addEventListener('click', () => {
   downloadData();
 });
+
+const fileInput = document.getElementById('file-input');
+const dropZone = document.getElementById('drop-zone');
+
+// 1. Handle File Selection via File Explorer Browsing
+if (fileInput) {
+  fileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) handleFileContent(file);
+  });
+}
+
+// 2. Handle Drag & Drop Events with proper overrides
+if (dropZone) {
+  // Prevent default behavior for all drag events to avoid browser navigation
+  ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+    dropZone.addEventListener(eventName, (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    }, false);
+  });
+
+  // Highlight drop zone when item is dragged over
+  ['dragenter', 'dragover'].forEach(eventName => {
+    dropZone.addEventListener(eventName, () => {
+      dropZone.classList.add('paste-zone--dragover');
+    }, false);
+  });
+
+  // Remove highlight when item leaves or is dropped
+  ['dragleave', 'drop'].forEach(eventName => {
+    dropZone.addEventListener(eventName, () => {
+      dropZone.classList.remove('paste-zone--dragover');
+    }, false);
+  });
+
+  // 3. Handle the File Drop Event correctly
+  dropZone.addEventListener('drop', (e) => {
+    const dt = e.dataTransfer;
+    if (dt && dt.files.length > 0) {
+      const file = dt.files[0];
+      handleFileContent(file);
+    }
+  });
+}
+
+// 4. File Reader Processor Function
+function handleFileContent(file) {
+  const allowedExtensions = ['txt', 'md', 'json'];
+  const fileExtension = file.name.split('.').pop().toLowerCase();
+
+  // Validate file extension type
+  if (!allowedExtensions.includes(fileExtension)) {
+    alert('Invalid file format. Please upload a .txt, .md, or .json file.');
+    return;
+  }
+
+  const reader = new FileReader();
+  
+  reader.onload = (e) => {
+    const pasteInput = document.getElementById('paste-input');
+    if (pasteInput) {
+      pasteInput.value = e.target.result;
+      
+      alert(`Loaded "${file.name}" successfully! Click "Extract with AI" to find your tasks.`);
+    }
+  };
+
+  reader.onerror = () => {
+    alert('Error reading file content. Please try again.');
+  };
+
+  reader.readAsText(file);
+}


### PR DESCRIPTION
# Related Issue
Closes #369 

# Summary
"Smart Paste" panel requires users to manually copy and paste textual content (such as syllabus information or notes) into the text area element (#paste-input) inside index.html. This workflow is inconvenient for students who keep their course plans or schedules saved as standalone document files (e.g., .txt, .md, or .json files), forcing them to open the file in another program, copy the contents, switch back to the application, and manually paste it.

# Changes Made
1. Modified index.html
2. Updated Interactive Events in js/app.js
3. Updated Visual Feedback in css/index.css

# Testing
Uploaded a custom file to test the custom drag and drop

# Walkthrough
https://github.com/user-attachments/assets/a23647da-a4d9-4dec-b571-a0847769f12d


# Checklist
- [✓] Code follows project style
- [✓] Tested locally
- [✓] No unrelated changes included




