### PR TITLE
fix: rename duplicate clearBtn variable to clearFocusBtn in renderFoc…

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -368,9 +368,9 @@ function renderFocusTasks() {
         });
       }
       
-      const clearBtn = activeFocusTask.querySelector('.clear-focus-task-btn');
-      if (clearBtn) {
-        clearBtn.addEventListener('click', () => {
+      const clearFocusBtn = activeFocusTask.querySelector('.clear-focus-task-btn');
+      if (clearFocusBtn) {
+        clearFocusBtn.addEventListener('click', () => {
           activeFocusTaskId = null;
           renderFocusTasks();
         });


### PR DESCRIPTION
Fixes #693 

**Problem**
The clearBtn variable was declared twice in app.js:
- First at the top level:
  const clearBtn = document.getElementById('clear-btn')
- Second inside renderFocusTasks():
  const clearBtn = activeFocusTask.querySelector('.clear-focus-task-btn')

This variable shadowing caused:
- The inner clearBtn shadowing the outer clearBtn
- Clear button event listeners potentially conflicting
- Confusing and error-prone code

**Fix**
Renamed the inner clearBtn to clearFocusBtn inside 
renderFocusTasks() to eliminate the variable shadowing.
Updated all 3 references in that block accordingly.

**Testing**
- Clear button in focus task works correctly ✅
- Main clear button still works correctly ✅
- No variable shadowing in app.js ✅