### PR TITLE
fix: reset timePassed when timer duration is changed in study timer

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -265,7 +265,8 @@ function resetTimer() {
 }
 
 timerDurationInput.addEventListener('change', () => {
-  if (!timerInterval && timePassed === 0) {
+  if (!timerInterval) {
+    timePassed = 0;
     TIME_LIMIT = getTimerDuration();
     timeLeft = TIME_LIMIT;
     timerText.innerHTML = formatTimeLeft(timeLeft);


### PR DESCRIPTION
Fixes #696 

**Problem**
When a user changes the timer duration after pausing mid-session,
timePassed was never reset to 0. This caused:
- Restarting timer after duration change uses stale timePassed
- Timer shows wrong remaining time
- Timer ends earlier than expected duration

**Fix**
Added timePassed = 0 inside the timerDurationInput change 
handler so elapsed time is always reset when duration changes.
Also removed the timePassed === 0 condition since we now 
always reset it on duration change.

**Testing**
- Start timer for 25 mins, pause at 5 mins ✅
- Change duration to 10 mins ✅
- Restart timer — shows correct 10 mins remaining ✅
- Normal timer flow still works correctly ✅