### PR TITLE
fix(nlp): add support for "end of year" date parsing in fallback extractor

### DIFF
--- a/server.js
+++ b/server.js
@@ -131,6 +131,9 @@ function nlpExtractDate(text, now = new Date()) {
   if (/\bend of (the\s+)?month\b/.test(lower)) {
     return nlpStartOf(new Date(now.getFullYear(), now.getMonth() + 1, 0)).toISOString();
   }
+  if (/\bend of (the\s+)?year\b/.test(lower)) {
+  return nlpStartOf(new Date(now.getFullYear(), 11, 31)).toISOString();
+  }
   if (/\bnext month\b/.test(lower)) {
     const d = new Date(now); d.setMonth(d.getMonth() + 1);
     return nlpStartOf(d).toISOString();


### PR DESCRIPTION
# Related Issue

Closes #675

# Summary

Adds support for parsing the phrase `"end of year"` in the server-side NLP fallback extractor when the Gemini API is unavailable.

# Changes Made

* Added regex handling for `"end of year"` and `"end of the year"` inside `nlpExtractDate()`
* Aligned backend fallback behavior with frontend NLP parsing logic
* Ensured deadlines correctly resolve to December 31 of the current year

# Testing

* Tested locally by disabling `GEMINI_API_KEY`
* Verified that phrases like `"Submit report by end of year"` now resolve correctly
* Confirmed existing date parsing behavior remains unchanged

# Screenshots

No UI changes.

# Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
* [x] Documentation updated (if applicable)
