### PR TITLE
fix: preserve new task drafts and restore task list rendering

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -753,6 +753,11 @@ body {
   background-color: rgba(0, 0, 0, 0.55) !important; 
 }
 
+#new-task-modal {
+  justify-content: flex-start;
+  padding: 24px 24px 24px max(24px, calc((100vw - 980px) / 2));
+}
+
 
 #new-task-modal .modal-card,
 #new-subject-modal .modal-card {
@@ -767,10 +772,27 @@ body {
   border: 1px solid rgba(148, 163, 184, 0.35)  !important;
 }
 
+#new-task-modal .modal-card {
+  max-width: 560px;
+  width: min(560px, calc(100vw - 96px));
+}
+
+#new-task-modal .modal-card-task {
+  position: relative;
+}
+
+#new-task-modal .new-task-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 
 #new-task-modal .modal-card h3,
 #new-subject-modal .modal-card h3 {
-  margin: 0 0 12px;
+  margin: 0;
   font-size: 18px;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -841,6 +863,13 @@ body {
   border-radius: 999px;
 }
 
+#new-task-close {
+  min-width: 36px;
+  line-height: 1;
+  font-size: 20px !important;
+  padding: 4px 0 !important;
+}
+
 #new-task-modal .btn:not(.btn-primary),
 #new-subject-modal .btn:not(.btn-primary) {
   background: rgba(15, 23, 42, 0.9);
@@ -871,9 +900,15 @@ body {
 
 
 @media (max-width: 480px) {
+  #new-task-modal {
+    justify-content: center;
+    padding: 16px;
+  }
+
   #new-task-modal .modal-card,
   #new-subject-modal .modal-card {
     max-width: 90vw;
+    width: 100%;
     padding: 16px 14px 12px;
   }
 }
@@ -2326,10 +2361,15 @@ body {
   background-color: rgba(0, 0, 0, 0.55) !important; 
 }
 
+#new-task-modal {
+  justify-content: flex-start;
+  padding: 24px 24px 24px max(24px, calc((100vw - 980px) / 2));
+}
+
 
 #new-task-modal .modal-card {
-  width: 100%;
-  max-width: 360px;
+  width: min(560px, calc(100vw - 96px));
+  max-width: 560px;
   background-color: #0f172a;                     
   border-radius: 14px;
   padding: 20px 20px 16px;
@@ -2339,9 +2379,21 @@ body {
   border: 1px solid rgba(148, 163, 184, 0.35)  !important;
 }
 
+#new-task-modal .modal-card-task {
+  position: relative;
+}
+
+#new-task-modal .new-task-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 
 #new-task-modal .modal-card h3 {
-  margin: 0 0 12px;
+  margin: 0;
   font-size: 18px;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -2404,6 +2456,13 @@ body {
   border-radius: 999px;
 }
 
+#new-task-close {
+  min-width: 36px;
+  line-height: 1;
+  font-size: 20px !important;
+  padding: 4px 0 !important;
+}
+
 #new-task-modal .btn:not(.btn-primary) {
   background: rgba(15, 23, 42, 0.9);
   color: #e5e7eb;
@@ -2432,8 +2491,14 @@ body {
 
 
 @media (max-width: 480px) {
+  #new-task-modal {
+    justify-content: center;
+    padding: 16px;
+  }
+
   #new-task-modal .modal-card {
     max-width: 90vw;
+    width: 100%;
     padding: 16px 14px 12px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -440,8 +440,11 @@
 </div>
 
 <div id="new-task-modal" class="modal-backdrop" style="display:none; position:fixed; inset:0;  z-index:9998; align-items:center; justify-content:center;">
-  <div class="modal-card" style=" border-radius:12px; padding:20px; width:320px; box-shadow:0 12px 40px rgba(0,0,0,0.25);">
-    <h3 style="margin:0 0 12px; font-size:18px; font-weight:600;">New task</h3>
+  <div class="modal-card modal-card-task" style=" border-radius:12px; padding:20px; box-shadow:0 12px 40px rgba(0,0,0,0.25);">
+    <div class="new-task-modal-header">
+      <h3 style="margin:0; font-size:18px; font-weight:600;">New task</h3>
+      <button id="new-task-close" type="button" class="btn" aria-label="Close new task form">&times;</button>
+    </div>
 
     <label style="display:block; font-size:12px; margin-bottom:4px;">Subject</label>
     <select id="new-task-subject" paceholder="Subject" style="width:100%; padding:6px; margin-bottom:10px;"></select>

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,13 @@ import { store } from './store.js';
 import { extractTasksFromText } from './utils/api.js';
 import { initGlobalErrorBoundary } from './utils/errorBoundary.js';
 import { analyzeWorkload } from './utils/scheduler.js';
+import {
+  buildPostSaveCalendarState,
+  buildDefaultNewTaskDateValue,
+  captureNewTaskFormState,
+  isNewTaskFormDirty as hasNewTaskDraftChanged,
+} from './utils/newTaskModal.mjs';
+import { joinMarkup } from './utils/taskMarkup.mjs';
 
 initGlobalErrorBoundary();
 
@@ -172,6 +179,8 @@ const newTaskDate = document.getElementById('new-task-date');
 const newTaskNotes = document.getElementById('new-task-notes');
 const newTaskCancel = document.getElementById('new-task-cancel');
 const newTaskSave = document.getElementById('new-task-save');
+const newTaskClose = document.getElementById('new-task-close');
+let newTaskInitialState = null;
 
 // Timer elements
 const timerText = document.getElementById('timer-text');
@@ -636,10 +645,12 @@ function renderTasks() {
          </div>`
       : '';
 
-    tasksSection.innerHTML = actionBar +
-                             renderGroup(`Tasks for ${selStr}`, dueSoon, 'var(--color-text-primary)') +
-                             renderGroup('Completed', completed, 'var(--color-text-tertiary)') +
-                             emptyState;
+    tasksSection.innerHTML = joinMarkup(
+      actionBar,
+      renderGroup(`Tasks for ${selStr}`, dueSoon, 'var(--color-text-primary)'),
+      renderGroup('Completed', completed, 'var(--color-text-tertiary)'),
+      emptyState
+    );
   } else {
     const actionBar = currentView === 'archived' ? '' : `<div class="tasks-actions-bar">
            <button id="mark-all-pending-btn" class="task-action-btn" ${pending.length === 0 ? 'disabled' : ''}>Mark all pending completed (${pending.length})</button>
@@ -665,11 +676,13 @@ function renderTasks() {
          </div>`
       : '';
 
-    tasksSection.innerHTML = actionBar +
-                             renderGroup(titlePrefix + '⚠ Due soon', dueSoon, 'var(--color-text-danger)', true)
-                             + renderGroup(titlePrefix + 'This week', thisWeek, 'var(--color-text-secondary)', true) +
-                             renderGroup(titlePrefix + 'Completed', completed, 'var(--color-text-tertiary)') +
-                             emptyState;
+    tasksSection.innerHTML = joinMarkup(
+      actionBar,
+      renderGroup(titlePrefix + '⚠ Due soon', dueSoon, 'var(--color-text-danger)', true),
+      renderGroup(titlePrefix + 'This week', thisWeek, 'var(--color-text-secondary)', true),
+      renderGroup(titlePrefix + 'Completed', completed, 'var(--color-text-tertiary)'),
+      emptyState
+    );
   }
 
   // Bind CTA button in empty state
@@ -1088,6 +1101,60 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 //NEw Task addition event listeners
+function populateNewTaskSubjects() {
+  newTaskSubject.innerHTML = store.subjects
+    .map(s => `<option value="${s.id}">${s.name}</option>`)
+    .join('');
+}
+
+function getNewTaskFormState() {
+  return captureNewTaskFormState({
+    subjectId: newTaskSubject.value,
+    title: newTaskTitle.value,
+    notes: newTaskNotes.value,
+    dueAt: newTaskDate.value,
+  });
+}
+
+function resetNewTaskForm() {
+  populateNewTaskSubjects();
+  newTaskDate.value = buildDefaultNewTaskDateValue(selectedDate);
+  newTaskTitle.value = '';
+  newTaskNotes.value = '';
+  newTaskInitialState = getNewTaskFormState();
+}
+
+function openNewTaskModal() {
+  resetNewTaskForm();
+  newTaskModal.style.display = 'flex';
+  newTaskModal.classList.add('showing');
+  newTaskTitle.focus();
+}
+
+function hideNewTaskModal() {
+  newTaskModal.style.display = 'none';
+  newTaskModal.classList.remove('showing');
+}
+
+function discardNewTaskDraft() {
+  hideNewTaskModal();
+  newTaskTitle.value = '';
+  newTaskNotes.value = '';
+  newTaskDate.value = '';
+  newTaskInitialState = null;
+}
+
+function confirmDiscardNewTask() {
+  const currentState = getNewTaskFormState();
+  if (!hasNewTaskDraftChanged(newTaskInitialState, currentState)) return true;
+  return window.confirm('Discard this task draft? Unsaved changes will be lost.');
+}
+
+function requestCloseNewTaskModal() {
+  if (!confirmDiscardNewTask()) return;
+  discardNewTaskDraft();
+}
+
 newTaskBtn.addEventListener('click', () => {
   
   if (!store.subjects || store.subjects.length === 0) {
@@ -1095,34 +1162,13 @@ newTaskBtn.addEventListener('click', () => {
     return;
   }
 
-  newTaskSubject.innerHTML = store.subjects
-    .map(s => `<option value="${s.id}">${s.name}</option>`)
-    .join('');
-
-
-  if (selectedDate) {
-    const d = new Date(selectedDate);
-    d.setHours(18, 0, 0, 0); 
-    newTaskDate.value = d.toISOString().substring(0, 16);
-  } else {
-    newTaskDate.value = '';
-  }
-
-  newTaskTitle.value = '';
-  newTaskNotes.value = '';
-
-  newTaskModal.style.display = 'flex';
+  openNewTaskModal();
 });
 
-newTaskCancel.addEventListener('click', () => {
-  newTaskModal.style.display = 'none';
-});
-
-newTaskModal.addEventListener('click', (e) => {
-  if (e.target === newTaskModal) {
-    newTaskModal.style.display = 'none';
-  }
-});
+newTaskCancel.addEventListener('click', requestCloseNewTaskModal);
+if (newTaskClose) {
+  newTaskClose.addEventListener('click', requestCloseNewTaskModal);
+}
 
 newTaskSave.addEventListener('click', async () => {
   const rawTitle = newTaskTitle.value.trim();
@@ -1149,8 +1195,22 @@ newTaskSave.addEventListener('click', async () => {
     labels
   };
 
-  await store.addTasks([newTask]);
-  newTaskModal.style.display = 'none';
+  const saved = await store.addTasks([newTask]);
+  if (!saved) return;
+
+  const postSaveCalendarState = buildPostSaveCalendarState(currentView, due_at);
+  if (postSaveCalendarState) {
+    selectedDate = postSaveCalendarState.selectedDate;
+    currentMonthDate = postSaveCalendarState.currentMonthDate;
+  }
+
+  discardNewTaskDraft();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  if (!newTaskModal || newTaskModal.style.display !== 'flex') return;
+  requestCloseNewTaskModal();
 });
 
 addItemsBtn.addEventListener('click', () => {

--- a/js/store.js
+++ b/js/store.js
@@ -79,7 +79,7 @@ export const store = {
         //  Backend error
         alert(`❌ ${data.message || "Failed to add tasks"}`);
         console.error('Add task error:', data);
-        return;
+        return false;
       }
 
       // ================= USER MESSAGES =================
@@ -104,10 +104,12 @@ export const store = {
       const tasksRes = await fetch('/api/tasks');
       this.tasks = await tasksRes.json();
       this.notify();
+      return true;
 
     } catch (e) {
       console.error('Failed to add tasks', e);
-      alert("❌ Network error. Please try again.");
+      alert("âŒ Network error. Please try again.");
+      return false;
     }
   },
 

--- a/js/utils/newTaskModal.mjs
+++ b/js/utils/newTaskModal.mjs
@@ -1,0 +1,50 @@
+export function buildDefaultNewTaskDateValue(selectedDate) {
+  if (!selectedDate) return '';
+
+  const deadline = new Date(selectedDate);
+  deadline.setHours(18, 0, 0, 0);
+
+  const year = deadline.getFullYear();
+  const month = String(deadline.getMonth() + 1).padStart(2, '0');
+  const day = String(deadline.getDate()).padStart(2, '0');
+  const hours = String(deadline.getHours()).padStart(2, '0');
+  const minutes = String(deadline.getMinutes()).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function captureNewTaskFormState({ subjectId = '', title = '', notes = '', dueAt = '' } = {}) {
+  return {
+    subjectId: String(subjectId),
+    title: String(title).trim(),
+    notes: String(notes).trim(),
+    dueAt: String(dueAt),
+  };
+}
+
+export function isNewTaskFormDirty(initialState, currentState) {
+  if (!initialState) return false;
+
+  return (
+    initialState.subjectId !== currentState.subjectId ||
+    initialState.title !== currentState.title ||
+    initialState.notes !== currentState.notes ||
+    initialState.dueAt !== currentState.dueAt
+  );
+}
+
+export function buildPostSaveCalendarState(currentView, dueAt) {
+  if (currentView !== 'calendar' || !dueAt) {
+    return null;
+  }
+
+  const dueDate = new Date(dueAt);
+  if (Number.isNaN(dueDate.getTime())) {
+    return null;
+  }
+
+  return {
+    selectedDate: new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate()),
+    currentMonthDate: new Date(dueDate.getFullYear(), dueDate.getMonth(), 1),
+  };
+}

--- a/js/utils/taskMarkup.mjs
+++ b/js/utils/taskMarkup.mjs
@@ -1,0 +1,3 @@
+export function joinMarkup(...parts) {
+  return parts.filter(Boolean).join('');
+}

--- a/tests/newTaskModal.test.mjs
+++ b/tests/newTaskModal.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildPostSaveCalendarState,
+  buildDefaultNewTaskDateValue,
+  captureNewTaskFormState,
+  isNewTaskFormDirty,
+} from '../js/utils/newTaskModal.mjs';
+
+test('buildDefaultNewTaskDateValue returns an empty value when no date is selected', () => {
+  assert.equal(buildDefaultNewTaskDateValue(null), '');
+});
+
+test('buildDefaultNewTaskDateValue normalizes the selected day to 18:00 local time', () => {
+  assert.equal(buildDefaultNewTaskDateValue('2026-05-24'), '2026-05-24T18:00');
+});
+
+test('captureNewTaskFormState trims user-entered text fields', () => {
+  assert.deepEqual(
+    captureNewTaskFormState({
+      subjectId: 'sub_1',
+      title: '  Review notes  ',
+      notes: '  Bring textbook  ',
+      dueAt: '2026-05-24T18:00',
+    }),
+    {
+      subjectId: 'sub_1',
+      title: 'Review notes',
+      notes: 'Bring textbook',
+      dueAt: '2026-05-24T18:00',
+    }
+  );
+});
+
+test('isNewTaskFormDirty returns false when the draft still matches its initial snapshot', () => {
+  const initialState = captureNewTaskFormState({
+    subjectId: 'sub_1',
+    title: '',
+    notes: '',
+    dueAt: '2026-05-24T18:00',
+  });
+
+  const currentState = captureNewTaskFormState({
+    subjectId: 'sub_1',
+    title: '   ',
+    notes: '',
+    dueAt: '2026-05-24T18:00',
+  });
+
+  assert.equal(isNewTaskFormDirty(initialState, currentState), false);
+});
+
+test('isNewTaskFormDirty returns true when any draft field changes', () => {
+  const initialState = captureNewTaskFormState({
+    subjectId: 'sub_1',
+    title: '',
+    notes: '',
+    dueAt: '2026-05-24T18:00',
+  });
+
+  const currentState = captureNewTaskFormState({
+    subjectId: 'sub_2',
+    title: 'Read chapter 4',
+    notes: '',
+    dueAt: '2026-05-24T18:00',
+  });
+
+  assert.equal(isNewTaskFormDirty(initialState, currentState), true);
+});
+
+test('buildPostSaveCalendarState keeps non-calendar views unchanged', () => {
+  assert.equal(buildPostSaveCalendarState('all-tasks', '2026-06-10T09:30:00.000Z'), null);
+});
+
+test('buildPostSaveCalendarState focuses the saved task day in calendar view', () => {
+  const result = buildPostSaveCalendarState('calendar', '2026-06-10T09:30:00.000Z');
+
+  assert.ok(result);
+  assert.equal(result.selectedDate.getFullYear(), 2026);
+  assert.equal(result.selectedDate.getMonth(), 5);
+  assert.equal(result.selectedDate.getDate(), 10);
+  assert.equal(result.currentMonthDate.getFullYear(), 2026);
+  assert.equal(result.currentMonthDate.getMonth(), 5);
+  assert.equal(result.currentMonthDate.getDate(), 1);
+});

--- a/tests/taskMarkup.test.mjs
+++ b/tests/taskMarkup.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { joinMarkup } from '../js/utils/taskMarkup.mjs';
+
+test('joinMarkup preserves each section in order', () => {
+  assert.equal(
+    joinMarkup('<div>actions</div>', '<div>due</div>', '<div>week</div>', '<div>done</div>'),
+    '<div>actions</div><div>due</div><div>week</div><div>done</div>'
+  );
+});
+
+test('joinMarkup skips empty markup fragments', () => {
+  assert.equal(
+    joinMarkup('<div>actions</div>', '', null, '<div>done</div>'),
+    '<div>actions</div><div>done</div>'
+  );
+});


### PR DESCRIPTION
# Related Issue
Closes #580 

# Summary
Fixes the new task creation flow so opening the deadline picker no longer closes the form or discards unsaved input. It also restores task card rendering in the task list, which previously showed the pending count button without displaying the actual task items.

# Changes Made
- Prevented the new task modal from closing on backdrop clicks.
- Added explicit modal close handling through `Cancel`, close button, and `Escape`.
- Added unsaved-draft confirmation before discarding new task form input.
- Kept the native `datetime-local` input and widened/repositioned the modal on desktop so the picker has room to open beside the form.
- Updated post-save calendar behavior to focus the saved task’s due date in calendar view.
- Fixed task list markup assembly so pending tasks render correctly again.
- Added helper modules for new-task modal state handling and safe markup joining.
- Added regression tests for modal draft-state behavior, post-save calendar focus, and task markup joining.


# Testing
Tested locally with:
- `node --test .\tests\exportIcs.test.js .\tests\newTaskModal.test.mjs .\tests\taskMarkup.test.mjs`
Result:
- 14 tests passed
- 0 tests failed

# Screenshots
<img width="1553" height="937" alt="image" src="https://github.com/user-attachments/assets/1869dcdc-cf39-4305-abb8-7bb43a85e4cd" />
<img width="1919" height="970" alt="image" src="https://github.com/user-attachments/assets/a1148ae3-ca74-406e-9ce2-91d0a7157ae2" />


# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)
