### PR TITLE
fix: rename 'Save Changes' to 'Close' in settings modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,8 +295,7 @@
       </div>
     </div>
 
-    <button id="settings-save" style="width:100%; padding:12px; background:var(--color-text-primary); color:var(--color-background-primary); border:none; border-radius:8px; font-size:14px; font-weight:600; cursor:pointer; margin-top:8px;">
-      Save Changes
+    <button id="settings-save" style="width:100%; padding:12px; background:var(--color-text-primary); color:var(--color-background-primary); border:none; border-radius:8px; font-size:14px; font-weight:600; cursor:pointer; margin-top:8px;">Close
     </button>
   </div>
 </div>
@@ -449,11 +448,8 @@ document.getElementById('auth-submit-btn').addEventListener('click', async () =>
   // Run on load
   loadPreferences();
 
-  // Save changes when user clicks "Save Changes"
+  // Close modal when user clicks Close button
   settingsSave.addEventListener('click', () => {
-    localStorage.setItem('studyplan_dark_mode', darkModeToggle.checked);
-    localStorage.setItem('studyplan_compact_view', compactViewToggle.checked);
-    loadPreferences();
     settingsModal.style.display = 'none';
   });
 


### PR DESCRIPTION
## Summary
Closes #572

Fixes misleading "Save Changes" button in the Settings modal.

## Problem
Settings changes (Dark Mode, Compact View, etc.) apply **instantly** 
on toggle via `change` event listeners. The "Save Changes" button at 
the bottom was misleading — it suggested changes were pending, but 
they were already applied.

## Fix
- Renamed button text from "Save Changes" → "Close"
- Simplified click handler to just close the modal
- Removed redundant `localStorage.setItem` calls from the button 
  (settings already save on toggle)

## Behavior
Before: Button said "Save Changes" but changes were already applied  
After: Button says "Close" — accurately reflects its actual function

## Files Changed
- `index.html` — button text + click handler