### PR TITLE
Fix header navigation and active view indication

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1398,6 +1398,23 @@ body {
   color: var(--color-text-primary);
 }
 
+.header-nav a.active {
+  color: var(--color-text-primary);
+  font-weight: 700;
+  position: relative;
+}
+
+.header-nav a.active::after {
+  background: var(--color-text-primary);
+  border-radius: 999px;
+  bottom: -8px;
+  content: '';
+  height: 2px;
+  left: 0;
+  position: absolute;
+  right: 0;
+}
+
 .profile-btn {
   padding: 8px 16px;
   border: none;

--- a/index.html
+++ b/index.html
@@ -53,11 +53,11 @@
     <h1 class="site-title">StudyPlan</h1>
   </div>
 
-  <nav class="header-nav">
-    <a href="#">Dashboard</a>
-    <a href="#">Tasks</a>
-    <a href="#">Calendar</a>
-    <a href="#" id="nav-settings">Settings</a>
+  <nav class="header-nav" aria-label="Primary navigation">
+    <a href="#dashboard" id="nav-dashboard" class="active" aria-current="page">Dashboard</a>
+    <a href="#tasks" id="nav-tasks">Tasks</a>
+    <a href="#calendar" id="nav-calendar">Calendar</a>
+    <a href="#settings" id="nav-settings">Settings</a>
   </nav>
 
   <div class="header-right">

--- a/js/app.js
+++ b/js/app.js
@@ -1033,28 +1033,63 @@ document.addEventListener('DOMContentLoaded', () => {
   const allTasksBtn = document.getElementById('all-tasks-btn');
   const archivedTasksBtn = document.getElementById('archived-tasks-btn');
   const focusModeBtn = document.getElementById('focus-mode-btn');
+  const navDashboard = document.getElementById('nav-dashboard');
+  const navTasks = document.getElementById('nav-tasks');
+  const navCalendar = document.getElementById('nav-calendar');
 
   function updateSidebarActive(id) {
     document.querySelectorAll('.sidebar .nav-item').forEach(el => el.classList.remove('active'));
     document.getElementById(id).classList.add('active');
   }
 
-  calendarBtn.addEventListener('click', () => {
+  function updateHeaderActive(id) {
+    document.querySelectorAll('.header-nav a').forEach(link => {
+      const isActive = link.id === id;
+      link.classList.toggle('active', isActive);
+      if (isActive) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function showCalendarView(headerLinkId = 'nav-calendar') {
     currentView = 'calendar';
     document.querySelector('.cal-section').classList.remove('hidden');
     document.getElementById('tasks-section').classList.remove('hidden');
     document.getElementById('focus-section').classList.add('hidden');
     updateSidebarActive('calendar-btn');
+    updateHeaderActive(headerLinkId);
     renderTasks();
-  });
+  }
 
-  allTasksBtn.addEventListener('click', () => {
+  function showTasksView() {
     currentView = 'all-tasks';
     document.querySelector('.cal-section').classList.add('hidden');
     document.getElementById('tasks-section').classList.remove('hidden');
     document.getElementById('focus-section').classList.add('hidden');
     updateSidebarActive('all-tasks-btn');
+    updateHeaderActive('nav-tasks');
     renderTasks();
+  }
+
+  calendarBtn.addEventListener('click', () => showCalendarView());
+  allTasksBtn.addEventListener('click', () => showTasksView());
+
+  navDashboard.addEventListener('click', (event) => {
+    event.preventDefault();
+    showCalendarView('nav-dashboard');
+  });
+
+  navTasks.addEventListener('click', (event) => {
+    event.preventDefault();
+    showTasksView();
+  });
+
+  navCalendar.addEventListener('click', (event) => {
+    event.preventDefault();
+    showCalendarView();
   });
 
   archivedTasksBtn.addEventListener('click', () => {
@@ -1063,6 +1098,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('tasks-section').classList.remove('hidden');
     document.getElementById('focus-section').classList.add('hidden');
     updateSidebarActive('archived-tasks-btn');
+    updateHeaderActive('');
     renderTasks();
   });
 
@@ -1073,6 +1109,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('tasks-section').classList.add('hidden');
       document.getElementById('focus-section').classList.remove('hidden');
       updateSidebarActive('focus-mode-btn');
+      updateHeaderActive('');
       renderFocusTasks();
     });
   }


### PR DESCRIPTION
## Related Issue
Addresses #684

## Summary
- connect the header Dashboard, Tasks, and Calendar links to the application's existing view-switching behavior
- replace inert placeholder links with meaningful navigation targets
- synchronize a visible active header state and `aria-current` for clearer keyboard and screen-reader navigation
- clear the top-level active state when users enter Focus Mode or Archived Tasks from the sidebar

## Implementation Note
StudyPlan is a vanilla JavaScript single-page application, so this reuses its existing view state rather than adding a routing dependency. Dashboard restores the planner overview, Tasks shows all tasks, and Calendar opens the calendar view.

## Testing
- `npm.cmd test`
- `node --check server.js`
- `node --experimental-default-type=module --check js/app.js`
- `git diff --check`
- confirmed the application serves the updated header navigation targets locally

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included