### PR TITLE
fix: add week view functionality to calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,7 @@
         <select id="label-filter" style="margin-left:auto; margin-right: 12px; padding: 6px; border-radius: 6px; border: 1px solid var(--color-border-secondary); background: var(--color-background-primary); color: var(--color-text-primary); outline: none; cursor: pointer;">
           <option value="">All Labels</option>
         </select>
-        <button class="btn">Week</button>
-        <button class="btn btn-primary"  id="add-task-btn">
+       <button class="btn" id="week-view-btn">Week</button> <button class="btn btn-primary"  id="add-task-btn">
           <svg width="12" height="12" fill="none" style="margin-right:2px"><path d="M6 1v10M1 6h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg> New task
         </button>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -838,7 +838,67 @@ const summaryBox = document.getElementById('summary-box');
 if (summaryBox) {
   summaryBox.innerHTML = generateSummary(store.tasks, store.subjects);
 }
+function renderWeekView() {
+  const calGrid = document.getElementById('cal-grid');
+  const calTitle = document.getElementById('cal-month-title');
+  if (!calGrid) return;
 
+  const today = new Date();
+  const startOfWeek = new Date(today);
+  startOfWeek.setDate(today.getDate() - today.getDay());
+
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(startOfWeek.getDate() + 6);
+
+  calTitle.textContent = `${startOfWeek.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} – ${endOfWeek.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
+
+  let html = `<div class="cal-day-label">Su</div><div class="cal-day-label">Mo</div><div class="cal-day-label">Tu</div><div class="cal-day-label">We</div><div class="cal-day-label">Th</div><div class="cal-day-label">Fr</div><div class="cal-day-label">Sa</div>`;
+
+  for (let i = 0; i < 7; i++) {
+    const day = new Date(startOfWeek);
+    day.setDate(startOfWeek.getDate() + i);
+
+    const isToday = day.toDateString() === today.toDateString();
+    const isSelected = selectedDate && day.toDateString() === selectedDate.toDateString();
+
+    const dayTasks = store.tasks.filter(t => {
+      if (t.archived || t.status === 'Done' || !t.due_at) return false;
+      return new Date(t.due_at).toDateString() === day.toDateString();
+    });
+
+    let indicatorHtml = '';
+    if (dayTasks.length > 0) {
+      indicatorHtml = `<div class="cal-day-indicators">`;
+      dayTasks.slice(0, 3).forEach(t => {
+        const sub = store.subjects.find(s => s.id === t.subject_id) || store.subjects[0];
+        indicatorHtml += `<div class="cal-day-indicator" style="background:${sub ? sub.color : 'var(--color-text-danger)'}"></div>`;
+      });
+      indicatorHtml += `</div>`;
+    }
+
+    const extraStyle = isSelected ? `border: 1.5px solid var(--color-text-primary);` : '';
+
+    html += `<div class="cal-day interactive-day ${isToday ? 'today' : ''}" data-day="${day.toISOString()}" style="${extraStyle}">
+      ${day.getDate()}
+      ${indicatorHtml}
+    </div>`;
+  }
+
+  calGrid.innerHTML = html;
+
+  document.querySelectorAll('.interactive-day').forEach(el => {
+    el.addEventListener('click', (e) => {
+      const clickedDate = new Date(e.currentTarget.getAttribute('data-day'));
+      if (selectedDate && clickedDate.toDateString() === selectedDate.toDateString()) {
+        selectedDate = null;
+      } else {
+        selectedDate = clickedDate;
+      }
+      renderWeekView();
+      renderTasks();
+    });
+  });
+}
 function renderCalendar() {
   const calTitle = document.getElementById('cal-month-title');
   const calGrid = document.getElementById('cal-grid');
@@ -1141,7 +1201,18 @@ document.addEventListener('DOMContentLoaded', () => {
     currentMonthDate.setMonth(currentMonthDate.getMonth() + 1);
     renderCalendar();
   });
-
+  const weekBtn = document.getElementById('week-view-btn');
+if (weekBtn) {
+  weekBtn.addEventListener('click', () => {
+    if (currentView === 'week') {
+      currentView = 'calendar';
+      renderCalendar();
+    } else {
+      currentView = 'week';
+      renderWeekView();
+    }
+  });
+}
 
 //NEw Task addition event listeners
 newTaskBtn.addEventListener('click', () => {


### PR DESCRIPTION
# Related Issue
Closes #872 

# Summary
This PR implements the Week view functionality for the calendar, allowing users to switch between monthly and weekly calendar views.

# Changes Made
Added id="week-view-btn" to the Week button in index.html
Added renderWeekView() function in js/app.js to display the current week's 7 days
Added event listener for the Week button to toggle between week and month view
Clicking Week again returns to the monthly calendar view
Removed duplicate Week button from index.html
# Testing
Tested locally at http://localhost:3000
Clicked Week button — calendar switches to weekly view showing current week
Clicked Week button again — calendar returns to monthly view
Verified today's date is highlighted correctly in week view
Verified task indicators appear on correct days in week view

# Screenshots
<img width="1499" height="860" alt="image" src="https://github.com/user-attachments/assets/01c5bf02-b571-47e3-8c28-f518d8da9edb" />
<img width="1504" height="877" alt="image" src="https://github.com/user-attachments/assets/85b299d5-ab42-4059-96d2-f32979e2264d" />


# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included

