### PR TITLE
Add responsive navbar styles for various devices

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -4975,3 +4975,87 @@ body {
 @keyframes slideDown {
   to { opacity: 0; transform: translateY(10px); }
 }
+/* Navbar Container */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+/* Navigation Links */
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  list-style: none;
+  flex-wrap: wrap;
+}
+
+/* Nav Link Styling */
+.nav-links a {
+  text-decoration: none;
+  font-size: 1rem;
+  transition: 0.3s ease;
+}
+
+/* Better Hover Effect */
+.nav-links a:hover {
+  opacity: 0.8;
+}
+
+/* Tablet Responsiveness */
+@media screen and (max-width: 992px) {
+  .navbar {
+    padding: 1rem;
+  }
+
+  .nav-links {
+    gap: 1rem;
+  }
+
+  .nav-links a {
+    font-size: 0.95rem;
+  }
+}
+
+/* Mobile Responsiveness */
+@media screen and (max-width: 768px) {
+
+  .navbar {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .nav-links {
+    justify-content: center;
+    margin-top: 1rem;
+    gap: 0.8rem;
+  }
+
+  .nav-links a {
+    font-size: 0.9rem;
+  }
+}
+
+/* Small Mobile Devices */
+@media screen and (max-width: 480px) {
+
+  .navbar {
+    padding: 0.8rem;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .nav-links a {
+    width: 100%;
+    display: block;
+    padding: 0.5rem 0;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #884 

# Summary
Improved navbar responsiveness across laptop, tablet, and mobile screen sizes by adding responsive media queries at the end of `index.css`.

# Changes Made
- Added responsive media queries for different screen widths.
- Improved navbar layout alignment on smaller devices.
- Adjusted spacing and gaps for navigation items.
- Enabled wrapping/stacking behavior for mobile screens.
- Enhanced readability and usability on tablets and mobiles.
- Kept changes isolated to CSS without modifying component structure.

# Testing
- Tested locally in browser responsive mode.
- Verified layout behavior on:
  - Small mobile screens (320px–480px)
  - Tablets and large mobiles (481px–768px)
  - Small laptops/tablets (769px–1024px)
- Confirmed navbar items no longer overflow or overlap.
- Checked that desktop layout remains unaffected.

# Screenshots
Add before/after screenshots showing navbar responsiveness on different screen sizes.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)