### PR TITLE
fix: remove duplicate "Add items to planner" button with same ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
 </div>
 
 
-      <button id="add-btn" class="add-btn" disabled>Add items to planner</button>
+  
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
There were two `<button id="add-btn">` elements in `index.html` with the same ID. Duplicate IDs break JavaScript since `document.getElementById()` can only return one element, making the button unreliable.

## Changes Made
- Removed the duplicate `id="add-btn"` button that was incorrectly placed outside the panel div
- Kept the original button inside the Right Panel where it belongs

## Type of Change
- Bug fix

## Testing
- Verified only one `add-btn` exists in the file
- App loads correctly at localhost:3000

Fixes #874