### PR TITLE
Add Docker Compose setup for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules/
+.git/
+.env
+.env.local
+studyplan.db
+studyplan.db-journal
+.DS_Store
+.vscode/
+.idea/

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ GEMINI_API_KEY=your_gen_ai_key_here
 
 # Server Port (optional, defaults to 3000)
 PORT=3000
+
+# SQLite database path (optional, defaults to ./studyplan.db)
+# Docker Compose sets this to /data/studyplan.db automatically
+# DB_PATH=/data/studyplan.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package.json ./
+RUN npm install && npm rebuild sqlite3 --build-from-source
+
+COPY . .
+
+ENV PORT=3000 \
+    DB_PATH=/data/studyplan.db \
+    NODE_ENV=production
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD node -e "fetch('http://localhost:3000').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -136,6 +136,44 @@ npm install
 
 ---
 
+## 🐳 Docker Development
+
+StudyPlan runs as a **single container** because Express serves both the API and static frontend, and SQLite is file-based (not a separate database server). Docker provides a consistent, reproducible environment for onboarding and local development.
+
+### Prerequisites
+
+- Docker Engine 24+ and Docker Compose v2 (`docker compose` CLI)
+- Copy [`.env.example`](.env.example) to `.env` and set `GEMINI_API_KEY` (optional — the app falls back to local NLP without it)
+
+### Quick Start
+
+```bash
+cp .env.example .env   # edit GEMINI_API_KEY
+docker compose up --build
+```
+
+Open → http://localhost:3000
+
+### Common Docker Commands
+
+| Command | Purpose |
+|---------|---------|
+| `docker compose up --build` | Build and start the stack |
+| `docker compose up -d` | Start detached |
+| `docker compose down` | Stop and remove containers (volume preserved) |
+| `docker compose down -v` | Stop and **delete** SQLite data |
+| `docker compose logs -f app` | Tail app logs |
+| `docker compose exec app npm test` | Run tests inside container |
+| `docker compose ps` | Show service health status |
+
+### Development Workflow
+
+- **Docker (recommended for onboarding):** one command, consistent Node 20 + sqlite3 build, persistent data in the `sqlite_data` volume
+- **Local npm (faster iteration):** use the bare-metal flow below — no Docker required for day-to-day UI changes
+- **Reset database:** `docker compose down -v` then `docker compose up --build`
+
+---
+
 ## 🔑 Environment Setup
 
 Create `.env`:
@@ -147,6 +185,8 @@ GEMINI_API_KEY=your_gen_ai_key_here
 ---
 
 ## ▶️ Run Locally
+
+Without Docker:
 
 ```bash
 node server.js
@@ -169,6 +209,9 @@ Open → http://localhost:3000
 │   ├──  app.js              # The main controller (handles DOM UI, event bindings, and Calendar)
 │   └──  store.js            # The Custom State Manager handling our frontend Pub/Sub state
 ├──  .env.example            # Template file for setting the GEMINI_API_KEY
+├──  .dockerignore           # Files excluded from Docker build context
+├──  Dockerfile              # Container image for the app
+├──  docker-compose.yaml     # Orchestrates the local Docker development stack
 ├──  .gitignore              # Tells git to ignore databases, environments, and node packages
 ├──  database.js             # Initializes the SQLite database and executes DB table schemas
 ├──  index.html              # The frontend structural entry point

--- a/database.js
+++ b/database.js
@@ -1,7 +1,8 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 
-const db = new sqlite3.Database(path.join(__dirname, 'studyplan.db'));
+const dbPath = process.env.DB_PATH || path.join(__dirname, 'studyplan.db');
+const db = new sqlite3.Database(dbPath);
 
 function initDb() {
   db.serialize(() => {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build: .
+    ports:
+      - "${PORT:-3000}:3000"
+    env_file:
+      - .env
+    environment:
+      PORT: 3000
+      DB_PATH: /data/studyplan.db
+    volumes:
+      - sqlite_data:/data
+    networks:
+      - studyplan-net
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  sqlite_data:
+
+networks:
+  studyplan-net:
+    driver: bridge


### PR DESCRIPTION
## Summary

This PR adds a root-level Docker Compose workflow so contributors can start the full StudyPlan stack with a single command.

- Adds `Dockerfile`, `.dockerignore`, and `docker-compose.yaml` for a single `app` service (Node 20 + Express + static frontend)
- Persists SQLite data via a named `sqlite_data` volume mounted at `/data`
- Adds health checks, restart policy (`unless-stopped`), and a shared `studyplan-net` bridge network
- Makes the database path configurable via `DB_PATH` in `database.js` (defaults unchanged for local npm dev)
- Documents prerequisites, quick start, common Docker commands, and development workflow in `README.md`

StudyPlan runs as one container because Express serves both the API and static assets, and SQLite is file-based rather than a separate database server.

## Test plan

- [x] `docker compose up --build` — container starts and healthcheck passes
- [x] `http://localhost:3000` — app responds with HTTP 200
- [x] `docker compose exec app npm test` — all 5 tests pass
- [ ] `docker compose down && docker compose up` — SQLite data persists across restarts
- [ ] `docker compose down -v && docker compose up --build` — fresh database with default subjects seeded
- [ ] Local `npm start` without Docker still works using `./studyplan.db`