### PR TITLE
fix: wire header navigation links to sidebar views (closes #636)

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,9 +54,9 @@
   </div>
 
   <nav class="header-nav">
-    <a href="#">Dashboard</a>
-    <a href="#">Tasks</a>
-    <a href="#">Calendar</a>
+    <a href="#" id="nav-dashboard">Dashboard</a>
+    <a href="#" id="nav-tasks">Tasks</a>
+    <a href="#" id="nav-calendar">Calendar</a>
     <a href="#" id="nav-settings">Settings</a>
   </nav>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1132,6 +1132,33 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // Header navigation wiring (fix for issue #636)
+  // Delegate to sidebar buttons so all view-switching logic stays DRY
+  const navDashboard = document.getElementById('nav-dashboard');
+  const navTasks = document.getElementById('nav-tasks');
+  const navCalendar = document.getElementById('nav-calendar');
+
+  if (navDashboard) {
+    navDashboard.addEventListener('click', (e) => {
+      e.preventDefault();
+      calendarBtn.click();
+    });
+  }
+
+  if (navTasks) {
+    navTasks.addEventListener('click', (e) => {
+      e.preventDefault();
+      allTasksBtn.click();
+    });
+  }
+
+  if (navCalendar) {
+    navCalendar.addEventListener('click', (e) => {
+      e.preventDefault();
+      calendarBtn.click();
+    });
+  }
+
   document.getElementById('cal-prev').addEventListener('click', () => {
     currentMonthDate.setMonth(currentMonthDate.getMonth() - 1);
     renderCalendar();


### PR DESCRIPTION
## Summary

Resolves #636

The header navigation links (**Dashboard**, **Tasks**, **Calendar**) in the top navbar were completely non-functional — all had empty `href="#"` attributes and no JavaScript event handling, so clicking them did nothing.

## Root Cause

- The three header `<a>` tags had no `id` attributes, making them impossible to target with JavaScript.
- No event listeners were registered for them in `app.js`.

## Changes

### `index.html`
Added unique `id` attributes to the three header navigation anchors:
- `#nav-dashboard` → Dashboard
- `#nav-tasks` → Tasks
- `#nav-calendar` → Calendar

### `js/app.js`
Registered `click` event listeners for the three header nav links inside `DOMContentLoaded`. Each handler:
- Calls `e.preventDefault()` to prevent page scroll-to-top behaviour.
- **Delegates to the corresponding sidebar button's `.click()`** — keeping the implementation completely DRY by reusing all existing view-switching, section-show/hide, badge-update, and sidebar-active-state logic.

| Header Link | Delegates to |
|-------------|--------------|
| Dashboard   | `#calendar-btn` (default home view) |
| Tasks       | `#all-tasks-btn` |
| Calendar    | `#calendar-btn` |

## Verification

- Confirmed: clicking **Dashboard** in the header switches to the calendar+tasks home view.
- Confirmed: clicking **Tasks** in the header shows the All Tasks view with the sidebar state updated.
- Confirmed: clicking **Calendar** in the header switches to the calendar view correctly.
- No regressions to sidebar, badge counts, or view-switching logic.
