### PR TITLE
fix-duplicate-Add-btn

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,13 +233,13 @@
       </div>
       <div id="summary-box" class="summary-box"></div>
 
-  <button id="add-btn" class="add-btn" disabled>
+  <!-- <button id="add-btn" class="add-btn" disabled>
     Add items to planner
-  </button>
+  </button> -->
 </div>
 
 
-      <button id="add-btn" class="add-btn" disabled>Add items to planner</button>
+      <!-- <button id="add-btn" class="add-btn" disabled>Add items to planner</button> -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Related Issue
Closes #874 

### Fix: Remove duplicate "Add items to planner" button

#### Changes Made

 Identified that the "Add items to planner" button was duplicated with the same `id="add-btn"`.
 Commented out both instances temporarily, as they were non-functional and causing duplication issues.

#### Current Status

* The button has been removed from the UI for now since it was not connected to any functionality.

#### Request for Clarification

Could you please clarify the intended functionality of the "Add items to planner" button?

Specifically:

* What action should be triggered on click?
* Should it add items to a list, open a modal, or navigate somewhere?
* What data should it handle or display?

Once clarified, I would be happy to implement the correct functionality in a follow-up PR.

Thank you!

