### PR TITLE
fix: remove duplicate calendarDownloadBtn declaration in js/app.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1381,8 +1381,6 @@ if (quoteEl) {
   quoteEl.textContent = quotes[index];
 }
 
-const calendarDownloadBtn = document.getElementById('calendar-download-btn');
-
 if (calendarDownloadBtn) {
   calendarDownloadBtn.addEventListener('click', () => {
     downloadCalendar();


### PR DESCRIPTION
## Summary
- Removed duplicate `const calendarDownloadBtn` declaration on line 1384 of `js/app.js`
- Variable was already declared at line 89, causing a `SyntaxError: Identifier 'calendarDownloadBtn' has already been declared` on page load

## Fix
The second `const calendarDownloadBtn = document.getElementById('calendar-download-btn');` on line 1384 has been removed. The existing declaration at line 89 is used instead.

## Testing
- Verified no duplicate declarations remain in the file
- The click event listener for the calendar download button still references the correctly declared variable

Fixes #899