### PR TITLE
fix: nlpStartOf() sets time to 00:00 instead of 23:59

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ function nlpAddDays(date, n) {
   const d = new Date(date); d.setDate(d.getDate() + n); return d;
 }
 function nlpStartOf(date) {
-  const d = new Date(date); d.setHours(23, 59, 0, 0); return d;
+  const d = new Date(date); d.setHours(0, 0, 0, 0); return d;
 }
 function nlpWithTime(dateStr, t) {
   const d = new Date(dateStr);


### PR DESCRIPTION
## Summary
- Fixed `nlpStartOf()` in `server.js` to set time to `00:00:00` instead of `23:59:00`
- All NLP-extracted task due dates now correctly use start-of-day timestamps

## Problem
The `nlpStartOf()` helper was setting `d.setHours(23, 59, 0, 0)` — the **end** of the day — despite its name implying start-of-day. This caused every task extracted via the NLP fallback parser to have `due_at` at 23:59 instead of 00:00.

## Fix
```javascript
// Before
d.setHours(23, 59, 0, 0);

// After
d.setHours(0, 0, 0, 0);
```

## Impact
- Task sorting and calendar display now use correct start-of-day semantics
- Deadline comparisons work as expected for NLP-extracted tasks
- Affects the NLP fallback path (when Gemini API is unavailable or fails)

Fixes #923