### PR TITLE
fix(nlp): parse day after tomorrow distinctly

### DIFF
--- a/js/utils/nlpDateExtractor.js
+++ b/js/utils/nlpDateExtractor.js
@@ -74,8 +74,8 @@ export function extractTime(text) {
 
 function matchRelativeDay(lower, now) {
   if (/\btoday\b/.test(lower)) return toISO(startOf(now));
-  if (/\btomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 1)));
   if (/\bday after tomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 2)));
+  if (/\btomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 1)));
   if (/\byesterday\b/.test(lower)) return toISO(startOf(addDays(now, -1))); // edge case
   return null;
 }

--- a/tests/nlpDateExtractor.test.js
+++ b/tests/nlpDateExtractor.test.js
@@ -1,41 +1,40 @@
+process.env.TZ = 'UTC';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { readFileSync } = require('node:fs');
-const { join } = require('node:path');
+const { resolve } = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 let nlpDateExtractorModule;
 
 async function loadNlpDateExtractor() {
   if (!nlpDateExtractorModule) {
-    const source = readFileSync(
-      join(__dirname, '..', 'js', 'utils', 'nlpDateExtractor.js'),
-      'utf8'
+    const moduleUrl = pathToFileURL(
+      resolve(__dirname, '..', 'js', 'utils', 'nlpDateExtractor.js')
     );
-    const encodedSource = Buffer.from(source).toString('base64');
-    // Load the browser ESM helper without changing the CommonJS package mode.
-    nlpDateExtractorModule = import(`data:text/javascript;base64,${encodedSource}`);
+    nlpDateExtractorModule = import(moduleUrl.href);
   }
 
   return nlpDateExtractorModule;
 }
 
-function assertLocalDate(date, year, monthIndex, day) {
-  assert.equal(date.getFullYear(), year);
-  assert.equal(date.getMonth(), monthIndex);
-  assert.equal(date.getDate(), day);
+function assertUtcDate(date, year, monthIndex, day) {
+  assert.equal(date.getUTCFullYear(), year);
+  assert.equal(date.getUTCMonth(), monthIndex);
+  assert.equal(date.getUTCDate(), day);
 }
 
 test('extractDate resolves day after tomorrow two days from now', async () => {
   const { extractDate } = await loadNlpDateExtractor();
-  const now = new Date(2026, 4, 29, 10, 0, 0, 0);
+  const now = new Date(Date.UTC(2026, 4, 29, 10, 0, 0, 0));
 
   const tomorrow = new Date(extractDate('submit math homework tomorrow', now));
   const dayAfterTomorrow = new Date(
     extractDate('submit math homework day after tomorrow', now)
   );
 
-  assertLocalDate(tomorrow, 2026, 4, 30);
-  assertLocalDate(dayAfterTomorrow, 2026, 4, 31);
+  assertUtcDate(tomorrow, 2026, 4, 30);
+  assertUtcDate(dayAfterTomorrow, 2026, 4, 31);
   assert.equal(
     dayAfterTomorrow.getTime() - tomorrow.getTime(),
     24 * 60 * 60 * 1000

--- a/tests/nlpDateExtractor.test.js
+++ b/tests/nlpDateExtractor.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+let nlpDateExtractorModule;
+
+async function loadNlpDateExtractor() {
+  if (!nlpDateExtractorModule) {
+    const source = readFileSync(
+      join(__dirname, '..', 'js', 'utils', 'nlpDateExtractor.js'),
+      'utf8'
+    );
+    const encodedSource = Buffer.from(source).toString('base64');
+    // Load the browser ESM helper without changing the CommonJS package mode.
+    nlpDateExtractorModule = import(`data:text/javascript;base64,${encodedSource}`);
+  }
+
+  return nlpDateExtractorModule;
+}
+
+function assertLocalDate(date, year, monthIndex, day) {
+  assert.equal(date.getFullYear(), year);
+  assert.equal(date.getMonth(), monthIndex);
+  assert.equal(date.getDate(), day);
+}
+
+test('extractDate resolves day after tomorrow two days from now', async () => {
+  const { extractDate } = await loadNlpDateExtractor();
+  const now = new Date(2026, 4, 29, 10, 0, 0, 0);
+
+  const tomorrow = new Date(extractDate('submit math homework tomorrow', now));
+  const dayAfterTomorrow = new Date(
+    extractDate('submit math homework day after tomorrow', now)
+  );
+
+  assertLocalDate(tomorrow, 2026, 4, 30);
+  assertLocalDate(dayAfterTomorrow, 2026, 4, 31);
+  assert.equal(
+    dayAfterTomorrow.getTime() - tomorrow.getTime(),
+    24 * 60 * 60 * 1000
+  );
+});


### PR DESCRIPTION
## What
Fixes the frontend NLP fallback so `day after tomorrow` resolves two days ahead instead of being swallowed by the shorter `tomorrow` match. This keeps the browser fallback behavior aligned with the server fallback and closes #939.

## How
Moved the `day after tomorrow` check before the generic `tomorrow` regex in `js/utils/nlpDateExtractor.js`. Added a focused Node regression test that imports the browser ESM helper through a `file://` URL, pins the timezone to UTC for deterministic date assertions, and verifies `tomorrow` and `day after tomorrow` resolve to distinct dates.

## Testing
- `npm test`
- `npx -y node@20 --test`
- `git diff --check`
- `node --input-type=module --check < js/utils/nlpDateExtractor.js`

## Risks / Notes
No UI change, so screenshots are not applicable. `npm ci` completed successfully and reported existing moderate audit findings; no dependencies were changed.

# Related Issue
Closes #939

# Summary
Corrects relative-day parsing in the frontend fallback extractor.

# Changes Made
- Prioritized `day after tomorrow` before the shorter `tomorrow` pattern.
- Added a regression test for the relative-day parser.
- Hardened the test after review by using a file URL import and UTC assertions.

# Screenshots
N/A - parser logic only.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (not applicable)