### PR TITLE
chore: record workspace baseline

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1408,6 +1408,76 @@ body {
   font-weight: 600;
 }
 
+/* Mobile responsive header */
+@media (max-width: 767px) {
+  .site-header {
+    padding: 12px 16px;
+    align-items: center;
+    position: relative;
+  }
+
+  .header-nav {
+    display: none;
+  }
+
+  .header-right {
+    display: none;
+  }
+
+  .mobile-menu-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 22px;
+    padding: 6px 10px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    border-radius: 8px;
+  }
+
+  .mobile-menu-btn:focus { outline: 2px solid var(--color-border-secondary); }
+
+  .mobile-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 16px;
+    right: 16px;
+    background: var(--color-background-primary);
+    border: 1px solid var(--color-border-tertiary);
+    border-radius: 10px;
+    box-shadow: var(--shadow-md);
+    padding: 12px;
+    z-index: 1200;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .mobile-menu.open {
+    display: flex;
+  }
+
+  .mobile-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .mobile-nav a {
+    color: var(--color-text-primary);
+    text-decoration: none;
+    padding: 8px 10px;
+    border-radius: 6px;
+  }
+
+  .mobile-nav a:hover { background: var(--color-background-secondary); }
+
+  .mobile-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+}
+
 /* Footer */
 .site-footer {
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -64,6 +64,22 @@
     <button class="profile-btn">Profile</button>
     <button class="profile-btn" id="logout-btn">Logout</button>
   </div>
+  <!-- Mobile menu button -->
+  <button class="mobile-menu-btn" aria-label="Open menu" aria-expanded="false">☰</button>
+
+  <!-- Mobile menu (hidden by default) -->
+  <div class="mobile-menu" id="mobile-menu" aria-hidden="true">
+    <nav class="mobile-nav">
+      <a href="#">Dashboard</a>
+      <a href="#">Tasks</a>
+      <a href="#">Calendar</a>
+      <a href="#" id="mobile-nav-settings">Settings</a>
+    </nav>
+    <div class="mobile-actions">
+      <button class="profile-btn">Profile</button>
+      <button class="profile-btn" id="mobile-logout-btn">Logout</button>
+    </div>
+  </div>
 </header>
 
 
@@ -397,6 +413,16 @@ document.getElementById('auth-submit-btn').addEventListener('click', async () =>
     // Refresh page state
     window.location.reload();
 });
+
+  // Mobile logout (same behavior)
+  const mobileLogout = document.getElementById('mobile-logout-btn');
+  if (mobileLogout) {
+    mobileLogout.addEventListener('click', () => {
+      localStorage.removeItem('studyplan_user');
+      document.getElementById('auth-modal').style.display = 'flex';
+      window.location.reload();
+    });
+  }
 
   // Settings Modal Logic
   const settingsModal = document.getElementById('settings-modal');

--- a/js/app.js
+++ b/js/app.js
@@ -1388,3 +1388,34 @@ if (calendarDownloadBtn) {
     downloadCalendar();
   });
 }
+
+// Mobile menu toggle
+(() => {
+  const mobileBtn = document.querySelector('.mobile-menu-btn');
+  const mobileMenu = document.getElementById('mobile-menu');
+  if (!mobileBtn || !mobileMenu) return;
+
+  mobileBtn.addEventListener('click', (e) => {
+    const open = mobileMenu.classList.toggle('open');
+    mobileBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    mobileMenu.setAttribute('aria-hidden', open ? 'false' : 'true');
+  });
+
+  // Close when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!mobileMenu.classList.contains('open')) return;
+    if (mobileMenu.contains(e.target) || mobileBtn.contains(e.target)) return;
+    mobileMenu.classList.remove('open');
+    mobileBtn.setAttribute('aria-expanded', 'false');
+    mobileMenu.setAttribute('aria-hidden', 'true');
+  });
+
+  // Close on Escape
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && mobileMenu.classList.contains('open')) {
+      mobileMenu.classList.remove('open');
+      mobileBtn.setAttribute('aria-expanded', 'false');
+      mobileMenu.setAttribute('aria-hidden', 'true');
+    }
+  });
+})();


### PR DESCRIPTION
Title: Fix: Navbar responsive on mobile (fixes #907)

Summary

Makes the site header responsive on small viewports by replacing the overflowing desktop nav with an accessible hamburger menu and mobile menu UI. Prevents link/profile overlap and horizontal overflow on devices ≤768px.
What I changed

Added a mobile hamburger button and mobile menu markup in index.html.
Added responsive styles and mobile-menu styling in css/index.css.
Added a small, accessible JS toggle (open/close, outside-click, Escape) in js/app.js.
Files modified

index.html — hamburger + mobile menu markup, mobile logout hook
css/index.css — media query for <=768px, mobile menu styles
js/app.js — mobile menu toggle IIFE (accessibility + close behavior)
Why

On narrow screens the header links and profile controls were overflowing and overlapping. This change collapses those controls into a single, touch-friendly menu while preserving access to Profile and Logout.
How to test

Run the app locally (open index.html in browser or run your dev server).
In browser DevTools set viewport width < 768px:
Verify the desktop nav and profile buttons are hidden.
Verify the hamburger (☰) is visible.
Click the hamburger: the mobile menu opens showing vertical nav links and Profile / Logout buttons.
Click outside the menu or press Escape: menu closes.
Confirm no horizontal scroll produced by the header.
Optionally test on a real mobile device and attach screenshots.
Accessibility / notes for reviewers

The hamburger button has aria-expanded and the menu toggles aria-hidden.
Menu closes with Escape and outside clicks to support keyboard and touch flows.
If maintainers prefer an animated slide-in or a different breakpoint, I can adjust easily.
PR checklist

 Includes responsive CSS and minimal JS only
 Keeps profile/logout accessible on mobile
 No layout regressions at larger breakpoints (desktop behavior unchanged)
 (Optional) Add screenshot(s) demonstrating mobile before/after