### PR TITLE
fix: remove duplicate ID selectors in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
       <a id="auth-toggle-btn" href="#" style="color:#4f46e5; font-weight:600; margin-left:4px;">Sign Up</a>
     </p>
 
-    <p id="auth-error" style="color:red; font-size:13px; text-align:center; margin:8px 0 0; display:none;"></p>
   </div>
 </div>
 
@@ -237,9 +236,6 @@
     Add items to planner
   </button>
 </div>
-
-
-      <button id="add-btn" class="add-btn" disabled>Add items to planner</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #854

Removes duplicate id=auth-error (appeared twice) and duplicate id=add-btn (appeared twice) to resolve JS selector conflicts.