### PR TITLE
fix(app): resolve variable redeclaration syntax error (#899)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1381,8 +1381,6 @@ if (quoteEl) {
   quoteEl.textContent = quotes[index];
 }
 
-const calendarDownloadBtn = document.getElementById('calendar-download-btn');
-
 if (calendarDownloadBtn) {
   calendarDownloadBtn.addEventListener('click', () => {
     downloadCalendar();


### PR DESCRIPTION
# Related Issue
Closes #899

# Summary
This pull request resolves a critical JavaScript syntax error thrown on page load by removing a duplicate variable declaration in the frontend application script.

# Changes Made
- Removed the duplicate `const calendarDownloadBtn` declaration on line 1384 of `js/app.js` to resolve the browser crash.
- Retained the original declaration on line 89 to bind the element and handle the calendar download click event listener.

# Testing
- Verified syntactical validity of the modified script using Node.js syntax compiler: `node -c js/app.js` (successfully parsed without errors).
- Verified programmatically using a custom file scanner script to confirm that `calendarDownloadBtn` is declared exactly once in the file.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)

