### PR TITLE
fix(security): add rate limiting to /api/extract to prevent API key exhaustion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,11 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "sqlite3": "^6.0.1"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=20.x"
       }
     },
     "node_modules/@google/genai": {
@@ -612,6 +613,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -951,6 +970,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "sqlite3": "^6.0.1"
   },
   "engines": {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const { db, initDb } = require('./database');
 const { GoogleGenAI } = require('@google/genai');
 const path = require('path');
 const csvDownloadRouter = require('./backend/routers/csvDownload.router.js');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 app.use(cors());
@@ -474,7 +475,15 @@ app.delete('/api/tasks/:id', (req, res) => {
 });
 
 // ================= AI EXTRACTION =================
-app.post('/api/extract', async (req, res) => {
+const extractLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 requests per windowMs
+  message: { error: 'Too many extraction requests from this IP, please try again after 15 minutes' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+app.post('/api/extract', extractLimiter, async (req, res) => {
   const { text } = req.body;
   if (!text) return res.status(400).json({ error: 'Text is required' });
 


### PR DESCRIPTION
## 🔒 Fix: Add Rate Limiting to AI Extraction Endpoint

Closes #927

### Security Issue
The `/api/extract` endpoint (which connects to the Gemini AI API) was completely unauthenticated and had no rate limiting. This meant a malicious user could spam the endpoint, causing the server to exhaust the `GEMINI_API_KEY` quota or rack up billing charges, leading to a Denial of Service (DoS) for legitimate users.

### Solution
- Installed `express-rate-limit`.
- Added an `extractLimiter` middleware explicitly applied to `app.post('/api/extract', ...)`.
- Limited requests to 20 per IP per 15 minutes to allow legitimate usage while strictly blocking automated spam attacks.
