### PR TITLE
fix(security): prevent CSV format corruption and formula injection in export

### DIFF
--- a/backend/controllers/csvDownload.controller.js
+++ b/backend/controllers/csvDownload.controller.js
@@ -36,6 +36,14 @@ function formatIcsDate(dateInput) {
   return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
 }
 
+function escapeCsvField(value) {
+  let str = String(value || '');
+  if (/^[=+\-@]/.test(str)) {
+    str = "'" + str; // Prevent formula injection
+  }
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
 function buildCalendarIcs(tasks = []) {
   const dtstamp = formatIcsDate(new Date().toISOString());
   const events = tasks
@@ -81,14 +89,14 @@ async function downloadData(req, res) {
     const rows = [
       ['Task ID', 'Subject', 'Title', 'Due At', 'Status', 'Priority', 'Confidence Score', 'Notes'],
       ...data.map(task => [
-        task.id,
-        task.subject_name,
-        task.title,
-        task.due_at,
-        task.status,
-        task.priority,
-        task.confidence_score,
-        `"${(task.notes || '').replace(/"/g, '""')}"`,
+        escapeCsvField(task.id),
+        escapeCsvField(task.subject_name),
+        escapeCsvField(task.title),
+        escapeCsvField(task.due_at),
+        escapeCsvField(task.status),
+        escapeCsvField(task.priority),
+        escapeCsvField(task.confidence_score),
+        escapeCsvField(task.notes),
       ]),
     ];
 
@@ -123,4 +131,5 @@ module.exports = {
   buildCalendarIcs,
   formatIcsDate,
   escapeIcsText,
+  escapeCsvField,
 };


### PR DESCRIPTION
## 🔒 Fix: Prevent CSV Format Corruption and Formula Injection

Closes #969

### Problem
1. **Format Corruption:** If a user created a task with a title containing commas (e.g. `Task 1, and 2`), the CSV export treated the comma as a column delimiter because the field wasn't wrapped in quotes. This shifted all subsequent columns and broke the entire spreadsheet structure.
2. **Formula Injection (CSV Injection):** A malicious user could create a task starting with formula characters (`=`, `+`, `-`, `@`). When opened in Excel, this would trigger macro/formula execution, leading to potential RCE or data exfiltration.

### Solution
- Created a robust `escapeCsvField()` utility.
- Every field is now properly converted to a string and safely wrapped in double quotes `""`.
- Internal double quotes are properly escaped by doubling them (`""`).
- If a field starts with a dangerous formula character (`=`, `+`, `-`, `@`), it is automatically prefixed with a single quote `'` to force spreadsheet processors to interpret the cell as raw text instead of an executable macro.
