### PR TITLE
fix: header nav links for Dashboard, Tasks, Calendar not functioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,9 +54,9 @@
   </div>
 
   <nav class="header-nav">
-    <a href="#">Dashboard</a>
-    <a href="#">Tasks</a>
-    <a href="#">Calendar</a>
+    <a href="#" id="nav-dashboard">Dashboard</a>
+    <a href="#" id="nav-tasks">Tasks</a>
+    <a href="#" id="nav-calendar">Calendar</a>
     <a href="#" id="nav-settings">Settings</a>
   </nav>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1132,6 +1132,34 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // Header nav links
+  document.getElementById('nav-dashboard')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    currentView = 'all-tasks';
+    document.querySelector('.cal-section').classList.add('hidden');
+    document.getElementById('tasks-section').classList.remove('hidden');
+    document.getElementById('focus-section').classList.add('hidden');
+    renderTasks();
+  });
+
+  document.getElementById('nav-tasks')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    currentView = 'all-tasks';
+    document.querySelector('.cal-section').classList.add('hidden');
+    document.getElementById('tasks-section').classList.remove('hidden');
+    document.getElementById('focus-section').classList.add('hidden');
+    renderTasks();
+  });
+
+  document.getElementById('nav-calendar')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    currentView = 'calendar';
+    document.querySelector('.cal-section').classList.remove('hidden');
+    document.getElementById('tasks-section').classList.remove('hidden');
+    document.getElementById('focus-section').classList.add('hidden');
+    renderTasks();
+  });
+
   document.getElementById('cal-prev').addEventListener('click', () => {
     currentMonthDate.setMonth(currentMonthDate.getMonth() - 1);
     renderCalendar();


### PR DESCRIPTION
Fixes #978

## Problem
The header navigation links for Dashboard, Tasks, and Calendar had `href="#"` with no click event handlers, making them do nothing when clicked.

## Changes
- Added `id` attributes (`nav-dashboard`, `nav-tasks`, `nav-calendar`) to the `<a>` tags in `index.html`
- Added click event handlers in `js/app.js` that toggle the correct view sections (same logic as the working sidebar buttons)
- All handlers call `e.preventDefault()` to prevent default anchor behavior

## Testing
- Dashboard link now shows the tasks section
- Tasks link now shows the tasks section
- Calendar link now shows the calendar section
- Settings link continues to open the settings modal (unchanged)