### PR TITLE
fix: RFC 4180 compliant CSV export for fields with commas/quotes (#862)

### DIFF
--- a/backend/controllers/csvDownload.controller.js
+++ b/backend/controllers/csvDownload.controller.js
@@ -74,6 +74,14 @@ function buildCalendarIcs(tasks = []) {
   ].join('\r\n');
 }
 
+function escapeCsvField(value) {
+  const str = value == null ? '' : String(value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
 async function downloadData(req, res) {
   try {
     const data = await getAllTasksWithSubjects();
@@ -81,14 +89,14 @@ async function downloadData(req, res) {
     const rows = [
       ['Task ID', 'Subject', 'Title', 'Due At', 'Status', 'Priority', 'Confidence Score', 'Notes'],
       ...data.map(task => [
-        task.id,
-        task.subject_name,
-        task.title,
-        task.due_at,
-        task.status,
-        task.priority,
-        task.confidence_score,
-        `"${(task.notes || '').replace(/"/g, '""')}"`,
+        escapeCsvField(task.id),
+        escapeCsvField(task.subject_name),
+        escapeCsvField(task.title),
+        escapeCsvField(task.due_at),
+        escapeCsvField(task.status),
+        escapeCsvField(task.priority),
+        escapeCsvField(task.confidence_score),
+        escapeCsvField(task.notes),
       ]),
     ];
 


### PR DESCRIPTION
Fixes CSV export corruption when task titles, notes, or other fields contain commas, double quotes, or newlines.

## Changes
- Added `escapeCsvField()` helper implementing RFC 4180 compliance
- Applied escaping to ALL CSV fields, not just Notes
- Fields containing commas, double quotes, or newlines are wrapped in double quotes
- Internal double quotes are escaped by doubling
- Removes the ad-hoc partial escaping that only covered Notes

Closes #862
