### PR TITLE
feat: Escape key dismisses confirmation dialogs (#864)

### DIFF
--- a/js/utils/toast.js
+++ b/js/utils/toast.js
@@ -82,7 +82,13 @@ class ToastManager {
       backdrop.style.animation = 'fadeIn 0.2s ease-out forwards';
       modal.style.animation = 'slideUp 0.2s ease-out forwards';
 
+      const onKeyDown = (e) => {
+        if (e.key === 'Escape') close(false);
+      };
+      document.addEventListener('keydown', onKeyDown);
+
       const close = (result) => {
+        document.removeEventListener('keydown', onKeyDown);
         backdrop.style.animation = 'fadeOut 0.2s ease-out forwards';
         modal.style.animation = 'slideDown 0.2s ease-out forwards';
         setTimeout(() => {


### PR DESCRIPTION
Adds Escape key support for custom confirmation dialogs created by Toast.confirm().

## Changes
- Adds keydown listener when confirmation modal opens
- Pressing Escape dismisses the dialog with `false` (same as clicking Cancel)
- Listener is properly cleaned up when dialog closes (via button, backdrop click, or Escape)

Closes #864
