### PR TITLE
fix: escape task title and notes when rendering edit fields

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -617,13 +617,13 @@ function renderTasks() {
             </select>
 
             <label style="display:block; font-size:10px; font-weight:700; color:var(--color-text-tertiary); text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;">Task Name</label>
-            <input class="board-edit-title edit-field" type="text" value="${t.title}${t.labels && t.labels.length > 0 ? ' #' + t.labels.join(' #') : ''}" style="width:100%; margin-bottom: 12px; font-size:13px; font-weight:600; padding:6px; border: 1px solid var(--color-border-secondary); border-radius: 4px; background: var(--color-background-primary); color: var(--color-text-primary);">
+            <input class="board-edit-title edit-field" type="text" value="${escapeHtml(t.title + (t.labels && t.labels.length > 0 ? ' #' + t.labels.join(' #') : ''))}" style="width:100%; margin-bottom: 12px; font-size:13px; font-weight:600; padding:6px; border: 1px solid var(--color-border-secondary); border-radius: 4px; background: var(--color-background-primary); color: var(--color-text-primary);">
 
             <label style="display:block; font-size:10px; font-weight:700; color:var(--color-text-tertiary); text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;">Deadline</label>
             <input class="board-edit-date edit-field" type="datetime-local" value="${localDate}" style="width:100%; margin-bottom: 12px; font-size:12px; padding:6px; border: 1px solid var(--color-border-secondary); border-radius: 4px; background: var(--color-background-primary); color: var(--color-text-primary);">
 
             <label style="display:block; font-size:10px; font-weight:700; color:var(--color-text-tertiary); text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;">Notes</label>
-            <input class="board-edit-notes edit-field" type="text" value="${t.notes || ''}" placeholder="Notes..." style="width:100%; margin-bottom: 12px; font-size:12px; padding:6px; border: 1px solid var(--color-border-secondary); border-radius: 4px; background: var(--color-background-primary); color: var(--color-text-primary);">
+            <input class="board-edit-notes edit-field" type="text" value="${escapeHtml(t.notes || '')}" placeholder="Notes..." style="width:100%; margin-bottom: 12px; font-size:12px; padding:6px; border: 1px solid var(--color-border-secondary); border-radius: 4px; background: var(--color-background-primary); color: var(--color-text-primary);">
 
             <label style="display:block; font-size:10px; font-weight:700; color:var(--color-text-tertiary); text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;">Priority</label>
             <select class="board-edit-priority edit-field" style="width:100%; margin-bottom: 12px; font-size:12px; padding:4px; border: 1px solid var(--color-border-secondary); border-radius: 4px; background: var(--color-background-primary); color: var(--color-text-primary);">


### PR DESCRIPTION
# Related Issue

Fixes #990 
Closes #990 

# Summary

Fixes an issue where task titles containing double quotes were truncated when opened in edit mode.

# Changes Made

* Escaped task title values before rendering edit inputs.
* Escaped task notes before rendering edit inputs.
* Preserved special characters such as quotation marks when editing tasks.
* Prevented malformed HTML attributes caused by unescaped user input.

# Testing

Tested locally with the following cases:

* A "B" C
* Hello "World"
* Notes containing quotation marks

Verified that:

* Tasks save correctly.
* Tasks display correctly in the task list.
* Edit mode shows the complete original text.
* Saving after editing preserves the full value.

# Screenshots

Before:

* Task displayed correctly in task list.
<img width="1055" height="627" alt="{BD9DE621-829D-4DB9-9D5E-03C14CDB8B85}" src="https://github.com/user-attachments/assets/cb0c7fac-89b6-4430-a3f0-763e4129280d" />

* Edit mode truncated text after the first quotation mark.
<img width="1345" height="668" alt="{BD5CB45D-83AD-4F82-9D81-32D62E7605E6}" src="https://github.com/user-attachments/assets/49ef368f-6e18-46e7-9d81-dad77f901664" />

After:

* Full task title appears correctly in edit mode.
<img width="848" height="375" alt="{A6ECA29D-152C-41BF-ACF7-99A603ED2C0E}" src="https://github.com/user-attachments/assets/f35f4f36-2a4f-485c-ac43-11b8aea0a2aa" />

# Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
* [x] Documentation updated (if applicable)
