### PR TITLE
fix: handle day after tomorrow before tomorrow

### DIFF
--- a/js/utils/nlpDateExtractor.js
+++ b/js/utils/nlpDateExtractor.js
@@ -74,8 +74,9 @@ export function extractTime(text) {
 
 function matchRelativeDay(lower, now) {
   if (/\btoday\b/.test(lower)) return toISO(startOf(now));
-  if (/\btomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 1)));
   if (/\bday after tomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 2)));
+  if (/\btomorrow\b/.test(lower)) return toISO(startOf(addDays(now, 1)));
+  
   if (/\byesterday\b/.test(lower)) return toISO(startOf(addDays(now, -1))); // edge case
   return null;
 }


### PR DESCRIPTION
# Related Issue
Closes #939

# Summary
Fixed incorrect parsing of the phrase "day after tomorrow" in the client-side NLP date extractor. The extractor was matching "tomorrow" before checking the longer phrase, causing both expressions to resolve to the same date.

# Changes Made
- Reordered relative date matching in `js/utils/nlpDateExtractor.js`.
- Checked `day after tomorrow` before `tomorrow`.
- Aligned frontend fallback behavior with the server-side fallback parser.
- Ensured `day after tomorrow` resolves to two days from the current date.

# Testing
Tested locally by parsing:
- `Submit math homework tomorrow`
- `Submit math homework day after tomorrow`

Verified that:
- `tomorrow` resolves to current date + 1 day.
- `day after tomorrow` resolves to current date + 2 days.

# Screenshots
N/A (No UI changes)

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)