### PR TITLE
Fix: CSV Injection and Calendar Formatting Bugs

### DIFF
--- a/backend/controllers/csvDownload.controller.js
+++ b/backend/controllers/csvDownload.controller.js
@@ -23,8 +23,18 @@ function escapeIcsText(value = '') {
     .replace(/;/g, '\\;');
 }
 
+// Complies with RFC 5545 (Max 75 characters per line)
+// Folds lines at 75 characters, appending CRLF + Space for continuation
+function foldIcsLine(line) {
+  if (line.length <= 75) return line;
+  return line.match(/.{1,74}/g).join('\r\n ');
+}
+
 function formatIcsDate(dateInput) {
   const date = new Date(dateInput);
+  
+  // Guard against Invalid Dates
+  if (isNaN(date.getTime())) return null;
 
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, '0');
@@ -38,17 +48,19 @@ function formatIcsDate(dateInput) {
 
 function buildCalendarIcs(tasks = []) {
   const dtstamp = formatIcsDate(new Date().toISOString());
+  
   const events = tasks
-    .filter(task => task.due_at)
+    .filter(task => task.due_at && !isNaN(new Date(task.due_at).getTime())) // Strict date validation
     .map(task => {
       const start = new Date(task.due_at);
-      const end = new Date(start.getTime() + 60 * 60 * 1000);
+      const end = new Date(start.getTime() + 60 * 60 * 1000); 
+      
       const description = [
         `Subject: ${task.subject_name || 'General'}`,
         `Status: ${task.status || 'Not Started'}`,
         `Priority: ${task.priority || 'medium'}`,
         `Notes: ${task.notes || 'None'}`,
-      ].join('\n');
+      ].join('\\n');
 
       return [
         'BEGIN:VEVENT',
@@ -59,7 +71,7 @@ function buildCalendarIcs(tasks = []) {
         `SUMMARY:${escapeIcsText(task.title || 'Untitled task')}`,
         `DESCRIPTION:${escapeIcsText(description)}`,
         'END:VEVENT',
-      ].join('\r\n');
+      ].map(foldIcsLine).join('\r\n'); // Apply line folding to every event attribute
     });
 
   return [
@@ -72,6 +84,26 @@ function buildCalendarIcs(tasks = []) {
     'END:VCALENDAR',
     '',
   ].join('\r\n');
+}
+
+// Prevents CSV Injection and formatting corruption
+function escapeCsvValue(value) {
+  if (value === null || value === undefined) return '';
+  let str = String(value);
+  
+  // 1. MITIGATE CSV INJECTION (Formula Injection)
+  // If string starts with a dangerous character (=, +, -, @, \t, \r), prepend a single quote
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = "'" + str;
+  }
+  
+  // 2. PREVENT FORMATTING CORRUPTION
+  // If string contains a quote, comma, or newline, it MUST be wrapped in quotes
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`; // Escape inner double-quotes
+  }
+  
+  return str;
 }
 
 async function downloadData(req, res) {
@@ -88,11 +120,14 @@ async function downloadData(req, res) {
         task.status,
         task.priority,
         task.confidence_score,
-        `"${(task.notes || '').replace(/"/g, '""')}"`,
+        task.notes,
       ]),
     ];
 
-    const csvString = rows.map(row => row.join(',')).join('\n');
+    // Apply the secure escape function to every single cell before joining
+    const csvString = rows
+      .map(row => row.map(escapeCsvValue).join(','))
+      .join('\n');
 
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', 'attachment; filename="study_data.csv"');


### PR DESCRIPTION
Title: Fix: Resolve CSV Injection vulnerability, CSV formatting corruption, and invalid ICS generation
Description:
This PR/Issue addresses a critical security vulnerability (CSV Injection) and several severe formatting bugs in the data export utilities (downloadData and downloadCalendar). These bugs currently allow malicious code execution via spreadsheet applications and cause exported .csv and .ics files to become corrupted and unusable depending on user input.

1. Security Vulnerability: CSV (Formula) Injection (Critical)

The Problem: The downloadData function does not sanitize user inputs (like title or notes) before exporting them to CSV. If a user inputs a string starting with =, +, -, @, \t, or \r (e.g., =cmd|' /C calc'!A0), spreadsheet software (Excel, Google Sheets) will execute it as a formula. This exposes users who download the CSV to arbitrary code execution or data exfiltration.

The Fix: Implemented an escapeCsvValue helper that prepends a single quote (') to any string starting with a dangerous character, forcing spreadsheet clients to evaluate the cell as plain text.

2. Bug: CSV Formatting Corruption (High)

The Problem: The CSV export simply joins fields with a comma (.join(',')). If user-generated fields (like task.title) contain commas, newlines, or quotes, the CSV row breaks entirely, shifting subsequent columns into the wrong places.

The Fix: The new escapeCsvValue helper wraps any string containing commas, newlines, or quotes in double quotes (""), properly escaping them according to standard CSV RFC 4180 specifications.

3. Bug: Invalid ICS Dates and Line-Length Limits (High / Medium)

The Problem: * buildCalendarIcs checks if task.due_at exists, but does not verify if it is a valid date. Parsing an invalid date string results in Invalid Date, which outputs NaNNaNNaNTNaNNaNNaNZ in the .ics file. This causes calendar clients (Google Calendar, Apple Calendar) to silently fail or reject the file.

The current ICS generator does not respect the iCalendar specification (RFC 5545), which strictly limits line lengths to 75 octets. Long task descriptions or titles will currently break strict calendar parsers.

The Fix: * Added a strict !isNaN(new Date(task.due_at).getTime()) check before processing events.

Implemented a foldIcsLine utility that splits strings exceeding 75 characters and inserts the required CRLF + Space for continuation lines.

Steps to Test:
Create a task with the title: =1+1 or =IMPORTDATA("http://malicious-site.com")

Create a task with the title: Read Chapter 1, 2, and 3

Create a task with an invalid date string in the database.

Download the CSV and verify that formulas are not executed (prepended with ') and commas do not create extra columns.

Download the ICS calendar and verify that NaN timestamps do not exist, and long description lines are properly folded with a space on the next line.

Checklist:
[x] Fixed CSV Injection vulnerability.

[x] Fixed CSV formatting for commas, quotes, and newlines.

[x] Fixed NaN timestamp generation in ICS export.

[x] Added RFC 5545 compliant line-folding for ICS files.