### PR TITLE
fix(ui): remove duplicate auth error element.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,6 @@
       <span id="auth-toggle-text">Don't have an account?</span>
       <a id="auth-toggle-btn" href="#" style="color:#4f46e5; font-weight:600; margin-left:4px;">Sign Up</a>
     </p>
-
-    <p id="auth-error" style="color:red; font-size:13px; text-align:center; margin:8px 0 0; display:none;"></p>
   </div>
 </div>
 


### PR DESCRIPTION
# Related Issue
Closes #1004 

# Summary
Fixes the duplicate auth error element in the login/signup modal.

# Changes Made
- Removed the duplicate `auth-error` paragraph from the auth modal in `index.html`.
- Kept a single error element so the DOM stays valid.
- Preserved the existing auth UI and behavior.

# Testing
Verified locally by running the app and confirming only one `auth-error` element remains in the auth modal. Also ran `npm test` successfully.

# Screenshots
Not applicable for this change.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)