### PR TITLE
feat: add study analytics dashboard

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -5013,3 +5013,176 @@ body {
 @keyframes slideDown {
   to { opacity: 0; transform: translateY(10px); }
 }
+.analytics-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px 24px 24px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.analytics-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.analytics-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.analytics-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.analytics-description {
+  max-width: 620px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.analytics-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.analytics-card,
+.subject-analytics-card {
+  background: var(--color-background-secondary);
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-md);
+  padding: 18px;
+  box-shadow: var(--shadow-sm);
+}
+
+.analytics-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: 10px;
+}
+
+.analytics-card-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.analytics-card-meta {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-text-tertiary);
+}
+
+.analytics-subjects {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analytics-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.analytics-section-header h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-text-primary);
+}
+
+.analytics-section-header p {
+  margin: 4px 0 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.subject-analytics-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.subject-analytics-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.subject-analytics-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.subject-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.subject-pill {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.subject-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.subject-subtitle {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.subject-percent {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.subject-progress {
+  width: 100%;
+  height: 10px;
+  background: var(--color-background-primary);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.subject-progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.analytics-empty-state {
+  padding: 24px;
+  text-align: center;
+  color: var(--color-text-secondary);
+  border: 1px dashed var(--color-border-secondary);
+  border-radius: var(--border-radius-md);
+}
+
+.analytics-empty-state strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 15px;
+  color: var(--color-text-primary);
+}

--- a/index.html
+++ b/index.html
@@ -93,6 +93,10 @@
         Archived Tasks
         <span class="badge">0</span>
       </div>
+      <div class="nav-item" id="analytics-btn" role="link" aria-label="View Analytics Dashboard">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M2 12h3v2H2v-2zm4-4h3v6H6V8zm4-3h3v9h-3V5zm4-3h3v12h-3V2z" fill="currentColor"/></svg>
+        Analytics
+      </div>
       <div class="nav-item" id="download-btn">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M2 4h12M2 8h9M2 12h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
         Download Data
@@ -154,7 +158,27 @@
       <!-- Tasks -->
       <div id="tasks-section" class="tasks-section">
         <!-- Javascript will inject tasks here -->
-        
+      </div>
+
+      <!-- Analytics -->
+      <div id="analytics-section" class="analytics-section hidden" aria-live="polite">
+        <div class="analytics-header">
+          <div>
+            <p class="analytics-label">Analytics</p>
+            <h2 class="analytics-title">Study performance at a glance</h2>
+            <p class="analytics-description">Track total tasks, completion progress, and subject-level insights without switching context.</p>
+          </div>
+        </div>
+        <div id="analytics-overview" class="analytics-overview-grid" role="region" aria-label="Analytics overview cards"></div>
+        <section class="analytics-subjects" aria-labelledby="subject-analytics-title">
+          <div class="analytics-section-header">
+            <div>
+              <h3 id="subject-analytics-title">Subject analytics</h3>
+              <p>Measure progress across your subjects and identify where work is concentrated.</p>
+            </div>
+          </div>
+          <div id="subject-analytics-grid" class="subject-analytics-grid"></div>
+        </section>
       </div>
 
       <!-- Focus Mode -->

--- a/js/app.js
+++ b/js/app.js
@@ -76,10 +76,10 @@ function generateSummary(tasks, subjects) {
 
 let currentMonthDate = new Date();
 let selectedDate = null;
-let currentView = 'calendar'; // 'calendar', 'all-tasks', 'archived'
+let currentView = 'calendar'; // 'calendar', 'all-tasks', 'archived', 'analytics', 'focus'
 
 const tasksSection = document.getElementById('tasks-section');
-const focusSection = document.getElementById('focus-section');
+const analyticsSection = document.getElementById('analytics-section');
 const extractPreview = document.getElementById('extract-preview');
 const pasteInput = document.getElementById('paste-input');
 const extractBtn = document.getElementById('extract-btn');
@@ -922,6 +922,76 @@ function renderCalendar() {
   });
 }
 
+function renderAnalytics() {
+  const overviewEl = document.getElementById('analytics-overview');
+  const subjectGrid = document.getElementById('subject-analytics-grid');
+  if (!overviewEl || !subjectGrid) return;
+
+  const tasks = store.tasks || [];
+  const subjects = store.subjects || [];
+  const now = new Date();
+
+  const totalTasks = tasks.length;
+  const completedTasks = tasks.filter(t => t.status === 'Done').length;
+  const pendingTasks = tasks.filter(t => !t.archived && t.status !== 'Done').length;
+  const overdueTasks = tasks.filter(t => !t.archived && t.status !== 'Done' && t.due_at && new Date(t.due_at) < now).length;
+  const overallCompletion = totalTasks === 0 ? 0 : Math.round((completedTasks / totalTasks) * 100);
+
+  const overviewItems = [
+    { title: 'Total Tasks', value: totalTasks, description: 'All tasks in your planner' },
+    { title: 'Completed Tasks', value: completedTasks, description: 'Tasks marked done' },
+    { title: 'Pending Tasks', value: pendingTasks, description: 'Active tasks not completed' },
+    { title: 'Overdue Tasks', value: overdueTasks, description: 'Pending tasks past deadline' },
+    { title: 'Overall Completion', value: `${overallCompletion}%`, description: 'Completion ratio across tasks' }
+  ];
+
+  overviewEl.innerHTML = overviewItems.map(item => `
+    <article class="analytics-card">
+      <div class="analytics-card-title">${item.title}</div>
+      <div class="analytics-card-value">${item.value}</div>
+      <p class="analytics-card-meta">${item.description}</p>
+    </article>
+  `).join('');
+
+  if (subjects.length === 0) {
+    subjectGrid.innerHTML = `
+      <div class="analytics-empty-state">
+        <strong>No subjects yet</strong>
+        <p>Add a subject to see subject-level progress and completion breakdown.</p>
+      </div>
+    `;
+    return;
+  }
+
+  const analyticsRows = subjects.map(subject => {
+    const subjectTasks = tasks.filter(t => t.subject_id === subject.id);
+    const subjectTotal = subjectTasks.length;
+    const subjectCompleted = subjectTasks.filter(t => t.status === 'Done').length;
+    const completionPct = subjectTotal === 0 ? 0 : Math.round((subjectCompleted / subjectTotal) * 100);
+    const safeColor = subject.color || 'var(--color-text-info)';
+
+    return `
+      <article class="subject-analytics-card">
+        <div class="subject-analytics-heading">
+          <div class="subject-label">
+            <span class="subject-pill" style="background:${safeColor}"></span>
+            <div>
+              <div class="subject-name">${escapeHtml(subject.name)}</div>
+              <div class="subject-subtitle">${subjectTotal} task${subjectTotal === 1 ? '' : 's'} · ${subjectCompleted} completed</div>
+            </div>
+          </div>
+          <div class="subject-percent">${completionPct}%</div>
+        </div>
+        <div class="subject-progress" aria-hidden="true">
+          <span class="subject-progress-fill" style="width:${completionPct}%; background:${completionPct >= 66 ? 'var(--color-text-success)' : completionPct >= 33 ? 'var(--color-text-warning)' : 'var(--color-text-info)'}"></span>
+        </div>
+      </article>
+    `;
+  }).join('');
+
+  subjectGrid.innerHTML = analyticsRows;
+}
+
 function renderExtraction() {
   const pasteItems = store.currentPaste;
   if (!pasteItems || pasteItems.length === 0) {
@@ -1025,6 +1095,7 @@ store.subscribe(renderTasks);
 store.subscribe(renderExtraction);
 store.subscribe(renderCalendar);
 store.subscribe(renderFocusTasks);
+store.subscribe(renderAnalytics);
 store.subscribe(renderSidebarSubjects);
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -1099,6 +1170,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('.cal-section').classList.remove('hidden');
     document.getElementById('tasks-section').classList.remove('hidden');
     document.getElementById('focus-section').classList.add('hidden');
+    document.getElementById('analytics-section')?.classList.add('hidden');
     updateSidebarActive('calendar-btn');
     renderTasks();
   });
@@ -1108,6 +1180,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('.cal-section').classList.add('hidden');
     document.getElementById('tasks-section').classList.remove('hidden');
     document.getElementById('focus-section').classList.add('hidden');
+    document.getElementById('analytics-section')?.classList.add('hidden');
     updateSidebarActive('all-tasks-btn');
     renderTasks();
   });
@@ -1117,6 +1190,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('.cal-section').classList.add('hidden');
     document.getElementById('tasks-section').classList.remove('hidden');
     document.getElementById('focus-section').classList.add('hidden');
+    document.getElementById('analytics-section')?.classList.add('hidden');
     updateSidebarActive('archived-tasks-btn');
     renderTasks();
   });
@@ -1127,8 +1201,22 @@ document.addEventListener('DOMContentLoaded', () => {
       document.querySelector('.cal-section').classList.add('hidden');
       document.getElementById('tasks-section').classList.add('hidden');
       document.getElementById('focus-section').classList.remove('hidden');
+      document.getElementById('analytics-section')?.classList.add('hidden');
       updateSidebarActive('focus-mode-btn');
       renderFocusTasks();
+    });
+  }
+
+  const analyticsBtn = document.getElementById('analytics-btn');
+  if (analyticsBtn) {
+    analyticsBtn.addEventListener('click', () => {
+      currentView = 'analytics';
+      document.querySelector('.cal-section').classList.add('hidden');
+      document.getElementById('tasks-section').classList.add('hidden');
+      document.getElementById('focus-section').classList.add('hidden');
+      document.getElementById('analytics-section')?.classList.remove('hidden');
+      updateSidebarActive('analytics-btn');
+      renderAnalytics();
     });
   }
 


### PR DESCRIPTION
## Description

This PR introduces a Study Analytics Dashboard to help users track their productivity and progress across subjects.

### Features Added

* Added Analytics navigation item in the sidebar
* Added analytics dashboard view
* Added overview cards displaying:

  * Total Tasks
  * Completed Tasks
  * Pending Tasks
  * Overdue Tasks
  * Overall Completion Percentage
* Added subject-wise analytics with progress indicators
* Added completion percentage calculations for each subject
* Ensured analytics update dynamically based on task data

### Implementation Details

* Reused existing task and subject data already available in the frontend store
* Added responsive analytics UI consistent with the current design system
* Preserved all existing functionality including:

  * Calendar
  * All Tasks
  * Focus Mode
  * Archived Tasks
  * CSV Export
  * Calendar Export

### Testing

Tested with:

* Completed tasks
* Pending tasks
* Overdue tasks
* Archived tasks
* Empty subject/task scenarios

Fixes #1010

<img width="904" height="536" alt="image" src="https://github.com/user-attachments/assets/c95f788a-e240-4cce-b06d-29b4025b2cd6" />

<img width="875" height="795" alt="image" src="https://github.com/user-attachments/assets/fe6861c9-2d22-4567-8072-4885d3bcc49c" />

Note: A true 7-day activity streak could not be implemented because the current schema does not track task completion timestamps. The dashboard currently provides task overview metrics, overdue tracking, completion percentage, and subject-wise analytics using existing task data.