### PR TITLE
fix: add show/hide password toggle to login modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,22 @@
 
     <input id="auth-email" type="email" placeholder="Email address" style="width:100%; padding:12px; border:1px solid #ddd; border-radius:8px; font-size:14px; margin-bottom:12px; box-sizing:border-box;">
     
-    <input id="auth-password" type="password" placeholder="Password" style="width:100%; padding:12px; border:1px solid #ddd; border-radius:8px; font-size:14px; margin-bottom:20px; box-sizing:border-box;">
+   <div style="position:relative; margin-bottom:20px;">
+  <input
+    id="auth-password"
+    type="password"
+    placeholder="Password"
+    style="width:100%; padding:12px 45px 12px 12px; border:1px solid #ddd; border-radius:8px; font-size:14px; box-sizing:border-box;"
+  >
 
+  <button
+    type="button"
+    id="toggle-password"
+    style="position:absolute; right:12px; top:50%; transform:translateY(-50%); border:none; background:none; cursor:pointer;"
+  >
+    👁️
+  </button>
+</div>
     <button id="auth-submit-btn" style="width:100%; padding:12px; background:#4f46e5; color:white; border:none; border-radius:8px; font-size:15px; font-weight:600; cursor:pointer;">
     Sign In
     </button>
@@ -305,6 +319,18 @@
 
   <script type="module" src="/js/app.js"></script>
   <script>
+    const passwordInput = document.getElementById('auth-password');
+const togglePassword = document.getElementById('toggle-password');
+
+if (passwordInput && togglePassword) {
+  togglePassword.addEventListener('click', () => {
+    const isPassword = passwordInput.type === 'password';
+
+    passwordInput.type = isPassword ? 'text' : 'password';
+    togglePassword.textContent = isPassword ? '🙈' : '👁️';
+  });
+}
+
   let isLogin = true;
 
   document.getElementById('auth-toggle-btn').addEventListener('click', (e) => {


### PR DESCRIPTION
# Related Issue

Closes #1063

# Summary

Added a show/hide password toggle to the login modal, allowing users to verify their password before submitting the form and improving the overall login experience.

# Changes Made

* Added a password visibility toggle button (👁️) next to the password field.
* Implemented JavaScript logic to switch between `password` and `text` input types.
* Updated the toggle icon dynamically based on the current visibility state.
* Preserved existing password validation and authentication functionality.

# Testing

* Verified that the password is hidden by default.
* Verified that clicking the toggle button reveals the password.
* Verified that clicking the toggle button again hides the password.
* Confirmed that login and signup validation continue to work as expected.
* Tested locally in the browser.

# Screenshots

Before:

* Password field did not provide any way to view entered text.

After:

* Password field includes a visibility toggle button.
* Users can switch between hidden and visible password states.

# Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
* [x] Documentation updated (if applicable)
