### PR TITLE
fix: update package main entry to server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "study-plan",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "start": "node server.js",
     "test": "node --test"


### PR DESCRIPTION
## Related Issue

Closes #1156

## Summary

This PR updates the `main` field in `package.json` from `index.js` to `server.js`.

The repository currently references `index.js` as the package entry point, but that file does not exist. The actual application entry point is `server.js`, which is already used by the start script.

## Changes Made

* Updated `"main": "index.js"` to `"main": "server.js"` in `package.json`

## Testing

* Verified package.json remains valid JSON
* Verified `npm install`
* Verified `npm start`
* Verified `node .` resolves correctly after the change
* No regressions introduced

## Screenshots

N/A

## Checklist

* [x] Tested locally
* [x] No breaking changes introduced
* [x] Linked related issue
