### PR TITLE
fix: correct midnight parsing to 00:00

### DIFF
--- a/js/utils/nlpDateExtractor.js
+++ b/js/utils/nlpDateExtractor.js
@@ -46,7 +46,7 @@ function withTime(dateStr, timeParts) {
 export function extractTime(text) {
   const lower = text.toLowerCase();
 
-  if (/\bmidnight\b/.test(lower)) return { hours: 23, minutes: 59 };
+  if (/\bmidnight\b/.test(lower)) return { hours: 0, minutes: 0 };
   if (/\bnoon\b/.test(lower)) return { hours: 12, minutes: 0 };
 
   // HH:MM am/pm

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ function nlpWithTime(dateStr, t) {
 }
 
 function nlpExtractTime(lower) {
-  if (/\bmidnight\b/.test(lower)) return { hours: 23, minutes: 59 };
+  if (/\bmidnight\b/.test(lower)) return { hours: 0, minutes: 0 };
   if (/\bnoon\b/.test(lower)) return { hours: 12, minutes: 0 };
   let m = lower.match(/\b(\d{1,2}):(\d{2})\s*(am|pm)?\b/);
   if (m) {


### PR DESCRIPTION
## Related Issue

Closes #1165

## Summary

This PR fixes an issue where the NLP time parser incorrectly maps `midnight` to `23:59`.

Midnight represents the start of a day (`00:00`), but the current implementation interprets it as one minute before the next day (`23:59`).

## Changes Made

* Updated midnight parsing in `server.js`
* Updated midnight parsing in `js/utils/nlpDateExtractor.js`
* Changed:

```js
{ hours: 23, minutes: 59 }
```

to:

```js
{ hours: 0, minutes: 0 }
```

## Testing

* Verified parser behavior for `midnight`
* Verified changes in both server-side and client-side parser implementations
* Verified no unrelated files were modified
* Existing tests pass

## Screenshots

N/A

## Checklist

* [x] Tested locally
* [x] Linked related issue
* [x] No breaking changes introduced
