### PR TITLE
feat: Add Dark Mode Support for Enhanced Accessibility and UI

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -52,8 +52,37 @@
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.08);
 }
 
+:root[data-theme="dark"] {
+  --color-background-primary: #181816;
+  --color-background-secondary: #20201e;
+  --color-background-tertiary: #272725;
+  --color-text-primary: #efede5;
+  --color-text-secondary: #a3a198;
+  --color-text-tertiary: #73726c;
+  --color-border-tertiary: rgba(255, 255, 255, 0.06);
+  --color-border-secondary: rgba(255, 255, 255, 0.12);
+  --color-border-primary: rgba(255, 255, 255, 0.22);
+  --color-text-danger: #fc9c9c;
+  --color-background-danger: rgba(252, 156, 156, 0.15);
+  --color-border-danger: rgba(252, 156, 156, 0.3);
+
+  --color-text-info: #9ecdfc;
+  --color-background-info: rgba(158, 205, 252, 0.15);
+  --color-border-info: rgba(158, 205, 252, 0.3);
+
+  --color-text-success: #a0d45a;
+  --color-background-success: rgba(160, 212, 90, 0.15);
+  --color-border-success: rgba(160, 212, 90, 0.3);
+
+  --color-text-warning: #fab35e;
+  --color-background-warning: rgba(250, 179, 94, 0.15);
+
+  --color-text-purple: #b9b5f5;
+  --color-background-purple: rgba(185, 181, 245, 0.15);
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --color-background-primary: #181816;
     --color-background-secondary: #20201e;
     --color-background-tertiary: #272725;

--- a/index.html
+++ b/index.html
@@ -98,6 +98,9 @@
         />
       </div>
     </div>
+    <button class="profile-btn" id="header-dark-mode-toggle" title="Toggle Dark Mode">
+      <i class="fas fa-moon"></i>
+    </button>
     <button class="profile-btn">Profile</button>
     <button class="profile-btn" id="logout-btn">Logout</button>
   </div>
@@ -487,20 +490,43 @@ document.getElementById('auth-submit-btn').addEventListener('click', async () =>
   // Settings Toggles State Management
   const darkModeToggle = document.getElementById('dark-mode-toggle');
   const compactViewToggle = document.getElementById('compact-view-toggle');
+  const headerDarkModeToggle = document.getElementById('header-dark-mode-toggle');
+
+  const updateDarkModeUI = (isDark) => {
+    if (isDark) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      if (headerDarkModeToggle) {
+        headerDarkModeToggle.innerHTML = '<i class="fas fa-sun"></i>';
+      }
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+      if (headerDarkModeToggle) {
+        headerDarkModeToggle.innerHTML = '<i class="fas fa-moon"></i>';
+      }
+    }
+    if (darkModeToggle) {
+      darkModeToggle.checked = isDark;
+    }
+  }
 
   // Load preferences
   const loadPreferences = () => {
-    const isDarkMode = localStorage.getItem('studyplan_dark_mode') === 'true';
+    // Check if user has explicitly set a preference, otherwise fallback to system preference
+    const storedPreference = localStorage.getItem('studyplan_dark_mode');
+    let isDarkMode;
+    
+    if (storedPreference !== null) {
+      isDarkMode = storedPreference === 'true';
+    } else {
+      // Check system preference
+      isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+    
     const isCompactView = localStorage.getItem('studyplan_compact_view') === 'true';
 
-    darkModeToggle.checked = isDarkMode;
-    compactViewToggle.checked = isCompactView;
+    updateDarkModeUI(isDarkMode);
 
-    if (isDarkMode) {
-      document.documentElement.setAttribute('data-theme', 'dark');
-    } else {
-      document.documentElement.setAttribute('data-theme', 'light');
-    }
+    compactViewToggle.checked = isCompactView;
 
     if (isCompactView) {
       document.body.classList.add('compact-view');
@@ -522,12 +548,17 @@ document.getElementById('auth-submit-btn').addEventListener('click', async () =>
 
   // Also apply immediately on toggle for better UX
   darkModeToggle.addEventListener('change', (e) => {
-    if (e.target.checked) {
-      document.documentElement.setAttribute('data-theme', 'dark');
-    } else {
-      document.documentElement.setAttribute('data-theme', 'light');
-    }
+    updateDarkModeUI(e.target.checked);
+    localStorage.setItem('studyplan_dark_mode', e.target.checked);
   });
+
+  if (headerDarkModeToggle) {
+    headerDarkModeToggle.addEventListener('click', () => {
+      const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      updateDarkModeUI(!isDark);
+      localStorage.setItem('studyplan_dark_mode', !isDark);
+    });
+  }
 
   compactViewToggle.addEventListener('change', (e) => {
     if (e.target.checked) {


### PR DESCRIPTION
# Related Issue
Closes #ISSUE_NUMBER

# Summary
Brief explanation of the contribution.

# Changes Made
- Bullet list of implemented changes.
- ...

# Testing
Explain how the changes were tested.

# Screenshots
Add screenshots if UI changes exist.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable)
   

## Description
This PR resolves #1183 by implementing a fully functional dark mode toggle for the StudyPlan web application, improving accessibility and reducing eye strain during late-night study sessions.

**Resolves:** #1183 

## Changes Made
- **Header Toggle:** Added a quick-access dark mode toggle button (`fa-moon`/`fa-sun`) to the main navigation header.
- **State Synchronization:** Linked the new header toggle with the existing Settings modal toggle so that both stay synchronized and reflect the current theme state.
- **CSS Architecture:** Refactored `index.css` to trigger dark mode using the `[data-theme="dark"]` attribute on the `:root` element, allowing explicit user override while preserving the automatic fallback to `@media (prefers-color-scheme: dark)`.
- **Persistence:** Configured the application to save the user's theme preference in `localStorage` so the UI remembers their choice across sessions and page reloads.

## Testing
- Verified that clicking the header toggle smoothly switches the interface between light and dark themes.
- Verified that the header toggle icon correctly alternates between a sun and a moon.
- Verified that the toggle state persists after a page reload.


<img width="1920" height="1032" alt="Screenshot 2026-06-24 025551" src="https://github.com/user-attachments/assets/c6fd3809-232f-4265-b662-af2008b0c846" />
