### PR TITLE
fix(calendar): Exclude tasks with invalid dates during ICS export.

### DIFF
--- a/backend/controllers/csvDownload.controller.js
+++ b/backend/controllers/csvDownload.controller.js
@@ -39,7 +39,11 @@ function formatIcsDate(dateInput) {
 function buildCalendarIcs(tasks = []) {
   const dtstamp = formatIcsDate(new Date().toISOString());
   const events = tasks
-    .filter(task => task.due_at)
+    .filter(task => {
+      if (!task.due_at) return false;
+      const d = new Date(task.due_at);
+      return !isNaN(d.getTime());
+    })
     .map(task => {
       const start = new Date(task.due_at);
       const end = new Date(start.getTime() + 60 * 60 * 1000);

--- a/tests/exportIcs.test.js
+++ b/tests/exportIcs.test.js
@@ -70,3 +70,19 @@ test('buildCalendarIcs skips tasks without due dates', () => {
 
   assert.doesNotMatch(output, /BEGIN:VEVENT/);
 });
+
+test('buildCalendarIcs skips tasks with invalid due dates', () => {
+  const output = buildCalendarIcs([
+    {
+      id: 'task_invalid_date',
+      title: 'Task with bad date',
+      due_at: 'invalid-date',
+      notes: '',
+      status: 'Not Started',
+      priority: 'medium',
+      subject_name: 'General',
+    },
+  ]);
+
+  assert.doesNotMatch(output, /BEGIN:VEVENT/);
+});


### PR DESCRIPTION

# Summary
This contribution resolves an iCalendar (.ics) export validation issue in the study planner export controller. It ensures that tasks containing invalid or unparseable date strings are excluded from calendar generation, maintaining a valid format that Google Calendar, Outlook, and Apple Calendar can import successfully.

# Changes Made
- **Calendar Filter Validation:** Refactored the task filtering in [csvDownload.controller.js]/ - StudyPlan/backend/controllers/csvDownload.controller.js 's `buildCalendarIcs()` to parse date objects and verify they are numeric timestamps via `!isNaN(new Date(task.due_at).getTime())` before exporting them.
- **Unit Testing Coverage:** Added a new unit test in [exportIcs.test.js](file:///Users/aakritirajhans/StudyPlan/tests/exportIcs.test.js) called `'buildCalendarIcs skips tasks with invalid due dates'` to verify that tasks with invalid date values are gracefully excluded from the generated `.ics` payload.

# Testing
- All 6 tests (including the new calendar date check test) pass successfully.
- Verified using the official [iCalendar.org validator](https://icalendar.org/validator.html). The generated `.ics` output with invalid date filtering successfully passes validation without errors.

# Checklist - All Satisfied
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] Documentation updated (if applicable) 
